### PR TITLE
New interval breakpoints and subdivsion - Resolves #69 

### DIFF
--- a/bin/call_variants.sh
+++ b/bin/call_variants.sh
@@ -9,6 +9,7 @@ set -u
 # $5 = ref genome
 # $6 = interval hash
 # $7 = interval_list
+# $8 = interval_padding
 
 # Create list of bams to be processed
 echo ${4} | tr ' ' '\n' > bam.list
@@ -22,4 +23,5 @@ gatk --java-options "-Xmx${2}G" HaplotypeCaller \
     --native-pair-hmm-threads ${1} \
     --min-base-quality-score 15 \
     --min-pruning 0 \
+    --interval-padding ${8} \
     -ERC GVCF

--- a/bin/create_bed_intervals.sh
+++ b/bin/create_bed_intervals.sh
@@ -3,20 +3,24 @@ set -e
 set -u
 ## args are the following:
 # $1 = cpus 
-# $2 = interval_splitn
-# $3 = interval_n
-# $4 = included_bed
-# $5 = included_padding
+# $2 = interval_n
+# $3 = interval_splitn
+# $4 = subdivide_intervals
+# $5 = included_bed
 # $6 = excluded_bed
 # $7 = excluded_padding
 # $8 = mitochondrial_contig
 # $9 = Reference_genome
 
+# parse filtering options as flags
+if [[ ${4} == "true" ]];   then SUBDIVISION_MODE="--subdivision-mode INTERVAL_SUBDIVISION "; \
+else SUBDIVISION_MODE="--subdivision-mode  BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW"; fi
+
 # Included intervals is just the reference genome bed if specific intervals were not provided
-cat ${4} > included_intervals.bed
+cat ${5} > included_intervals.bed
 
 # Convert any scientific notation to integers
-interval_splitlength=$(awk -v x="${2}" 'BEGIN {printf("%d\n",x)}') #TODO REMOVE INTERVAL SIZE
+interval_splitn=$(awk -v x="${2}" 'BEGIN {printf("%d\n",x)}') #TODO REMOVE INTERVAL SIZE
 interval_n=$(awk -v x="${3}" 'BEGIN {printf("%d\n",x)}')
 
 # Annotate any exluded intervals on the output bed
@@ -38,24 +42,24 @@ fi
 
 # TODO: Handle any extra filters (coverage, masks, etc)
 
-# Detect any strings of N bases in the reference genome
+# Detect any strings of N bases in the reference genome to define breakpoints
 java -jar $EBROOTPICARD/picard.jar ScatterIntervalsByNs \
       REFERENCE=${9}\
       OUTPUT_TYPE=BOTH \
-      OUTPUT=output.interval_list \
-	    MAX_TO_MERGE=${interval_splitlength}
+      OUTPUT=breakpoints.interval_list \
+	    MAX_TO_MERGE=${interval_splitn}
 
 # Convert resulting interval list to bed format
 java -jar $EBROOTPICARD/picard.jar IntervalListToBed \
-	INPUT=output.interval_list \
-	OUTPUT=intervals.bed
+	INPUT=breakpoints.interval_list \
+	OUTPUT=breakpoints.bed
 
 # Subtract any excluded intervals from the original list
-bedtools subtract -a intervals.bed -b excluded_intervals.bed > intervals_excluded.bed
+bedtools subtract -a breakpoints.bed -b excluded_intervals.bed > breakpoints_excluded.bed
 
-# Then add the excluded intervals to the end of it
-cat excluded_intervals.bed >> intervals_excluded.bed
-bedtools sort -i intervals_excluded.bed > interval_summary.bed
+# Then add the excluded intervals to the end of it to create a summary
+cat excluded_intervals.bed >> breakpoints_excluded.bed
+bedtools sort -i breakpoints_excluded.bed > interval_summary.bed
 
 # Filter intervals bedfile to just good intervals (ACGT bases) for creating windows
 awk '/ACGTmer/' interval_summary.bed > intervals_filtered.bed
@@ -65,7 +69,8 @@ gatk SplitIntervals \
    -R ${9} \
    -L intervals_filtered.bed \
    --scatter-count ${interval_n} \
-   -O $(pwd)
+   -O $(pwd) \
+   $SUBDIVISION_MODE
    
 # Rename and convert each split output into a bed, and add padding
 for i in *scattered.interval_list;do
@@ -77,13 +82,13 @@ for i in *scattered.interval_list;do
   	INPUT=$i \
   	OUTPUT=tmp.bed
 	
-  # Add padding to output
-  bedtools slop -i tmp.bed -g ${9}.fai -b ${5} > ${HASH}.bed
+  # Add padding to output - DO THIS IN GATK
+  #bedtools slop -i tmp.bed -g ${9}.fai -b ${5} > ${HASH}.bed
   
   # remove intermediate files
   rm $i tmp.bed
 done
 
 # Remove temporary files
-rm -f included_intervals.bed excluded_intervals.bed intervals_filtered.bed intervals_excluded.bed
+#rm -f included_intervals.bed excluded_intervals.bed intervals_filtered.bed intervals_excluded.bed
 

--- a/bin/create_bed_intervals.sh
+++ b/bin/create_bed_intervals.sh
@@ -34,26 +34,31 @@ fi
 
 # TODO: Add any extra filters (coverage, masks, etc) to the exclusion list here
 
-# Detect any strings of N bases in the reference genome to define breakpoints
-java -jar $EBROOTPICARD/picard.jar ScatterIntervalsByNs \
+# Locate appropriate breakpoints in the genome using strings of Ns
+if [ "${3}" -ge 1 ] ; then
+  # Detect any strings of N bases in the reference genome to define breakpoints
+  java -jar $EBROOTPICARD/picard.jar ScatterIntervalsByNs \
       --REFERENCE ${9}\
       --OUTPUT_TYPE BOTH \
       --OUTPUT breakpoints.interval_list \
 	    --MAX_TO_MERGE ${3}
+	    
+  # Convert resulting interval list to bed format
+  java -jar $EBROOTPICARD/picard.jar IntervalListToBed \
+  	--INPUT breakpoints.interval_list \
+  	--OUTPUT tmp.bed
+  	
+  # Subset the breakpoints bed to just the included intervals (this is just the genome bed if not provided)
+  bedtools intersect -wa -a tmp.bed -b included_intervals.bed | cut -f1-4 > breakpoints.bed
+  
+  # Subtract any of the excluded intervals - and subset  to just genotypable intervals (ACGTmers ) 
+  bedtools subtract -a breakpoints.bed -b excluded_intervals.bed | awk '/ACGTmer/' > intervals_filtered.bed
+  
+else
+  # Subtract any of the excluded intervals - and make summary file
+  bedtools subtract -a included_intervals.bed -b excluded_intervals.bed > intervals_filtered.bed
+done
 
-# Convert resulting interval list to bed format
-java -jar $EBROOTPICARD/picard.jar IntervalListToBed \
-	--INPUT breakpoints.interval_list \
-	--OUTPUT tmp.bed
-	
-# Subset the breakpoints bed to just the included intervals (this is just the genome bed if not provided)
-bedtools intersect -wa -a tmp.bed -b included_intervals.bed | cut -f1-4 > breakpoints.bed
-
-# Subtract any of the excluded intervals - and make summary file
-bedtools subtract -a breakpoints.bed -b excluded_intervals.bed > breakpoints_excluded.bed
-
-# Filter intervals bedfile to just genotypable intervals (ACGT bases)
-awk '/ACGTmer/' breakpoints_excluded.bed > intervals_filtered.bed
 
 # SPLIT INTERVALS into even groups
 gatk SplitIntervals \

--- a/bin/create_bed_intervals.sh
+++ b/bin/create_bed_intervals.sh
@@ -4,13 +4,14 @@ set -u
 ## args are the following:
 # $1 = cpus 
 # $2 = interval_n
-# $3 = interval_nbreaks
+# $3 = interval_break_n_length
 # $4 = subdivide_intervals
 # $5 = included_bed
 # $6 = excluded_bed
 # $7 = excluded_padding
 # $8 = mitochondrial_contig
 # $9 = Reference_genome
+# $9 = interval_break_n
 
 # parse subdivide_intervals options
 if [[ ${4} == "true" ]];   then SUBDIVISION_MODE="--subdivision-mode INTERVAL_SUBDIVISION "; \
@@ -35,7 +36,7 @@ fi
 # TODO: Add any extra filters (coverage, masks, etc) to the exclusion list here
 
 # Locate appropriate breakpoints in the genome using strings of Ns
-if [ "${3}" -ge 1 ] ; then
+if [ ${4} == "true" ] ; then
   # Detect any strings of N bases in the reference genome to define breakpoints
   java -jar $EBROOTPICARD/picard.jar ScatterIntervalsByNs \
       --REFERENCE ${9}\
@@ -53,11 +54,10 @@ if [ "${3}" -ge 1 ] ; then
   
   # Subtract any of the excluded intervals - and subset  to just genotypable intervals (ACGTmers ) 
   bedtools subtract -a breakpoints.bed -b excluded_intervals.bed | awk '/ACGTmer/' > intervals_filtered.bed
-  
 else
   # Subtract any of the excluded intervals - and make summary file
   bedtools subtract -a included_intervals.bed -b excluded_intervals.bed > intervals_filtered.bed
-done
+fi
 
 
 # SPLIT INTERVALS into even groups

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,17 +18,19 @@ params {
     samplesheet                 = null                              // path to samplesheet .csv file
     ref_genome                  = null                              // path to reference genome
     mito_contig                 = null                              // Name of mitochondrial contig
-
-
-    ///// Interval parameters
+    
+    // Fastq chunking
     fastq_chunk_size            = 5E6                               // number of reads .fastq files should be split into for mapping to genome
-    interval_n                  = 100                               // Create this many genomics for genotyping.
-    interval_nbreaks            = 100                               // Split contigs based on this string of this many N's in a row
-    subdivide_intervals         = false                             // Further subdivide intervals to balance number of bases in each parallel job
+
+    ///// Genomic Interval parameters
+    interval_n                  = 100                               // Create this many genomic intervals for parallel genotyping.
+    interval_break_n            = true                              // Whether to split contigs based on N breakpoints
+    interval_break_n_length     = 100                               // Split contigs based on this string of this many N's in a row.
+    interval_subdivide          = false                             // Automatically subdivide intervals to balance number of bases in each parallel job
     interval_bed                = null                              // Optional input bed file for included intervals
     interval_padding            = 100                               // Optional padding for included intervals
-    exclude_bed                 = null                              // Optional exclusion of certain intervals
-    exclude_padding             = 0                                 // Optional padding of exclusion intervals
+    interval_exclude_bed        = null                              // Optional exclusion of certain intervals
+    interval_exclude_padding    = 0                                 // Optional padding of exclusion intervals
 
     ///// read filtering (fastp) parameters
     rf_quality                  = 20                                // read minimum base quality (passed to 'fastp --qualified_quality_phred'); integer
@@ -131,7 +133,8 @@ profiles {
         params.ref_genome               = 'test_data/qfly/GCA_016617805.2_CM028320.1_50000-99999.fa' // Qfly genome subset to 50-100kb
         params.mito_contig              = 'HQ130030.1'
         params.interval_n               = 10
-        params.interval_nbreaks         = 1
+        params.interval_break_n         = true
+        params.interval_break_n_length  = 100
         params.subdivide_intervals      = true
         params.fastq_chunk_size	      	= 1000
         params.max_memory               = '2.GB'

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,8 +22,9 @@ params {
 
     ///// Interval parameters
     fastq_chunk_size            = 5E6                               // number of reads .fastq files should be split into for mapping to genome
-    interval_splitn             = 100                               // Split genomic intervals on this many N bases
-    interval_n                  = -1                                // Create this many genomic for genotyping. Set to -1 to disable parralel genotyping on
+    interval_n                  = 100                               // Create this many genomics for genotyping.
+    interval_nbreaks            = 100                               // Split contigs based on this string of this many N's in a row
+    subdivide_intervals         = false                             // Further subdivide intervals to balance number of bases in each parallel job
     interval_bed                = null                              // Optional input bed file for included intervals
     interval_padding            = 100                               // Optional padding for included intervals
     exclude_bed                 = null                              // Optional exclusion of certain intervals
@@ -129,9 +130,10 @@ profiles {
         params.samplesheet              = 'test_data/qfly/test_samplesheet.csv' // Qfly test data
         params.ref_genome               = 'test_data/qfly/GCA_016617805.2_CM028320.1_50000-99999.fa' // Qfly genome subset to 50-100kb
         params.mito_contig              = 'HQ130030.1'
-        params.interval_size            = -1    // disabled for test data 
-        params.interval_n               = 2 
-	params.fastq_chunk_size		= 1000
+        interval_n                      = 10
+        interval_nbreaks                = 1
+        subdivide_intervals             = true
+        params.fastq_chunk_size	      	= 1000
         params.max_memory               = '2.GB'
         params.max_time                 = '10.m'
         params.max_cpus                 = 1

--- a/nextflow.config
+++ b/nextflow.config
@@ -130,9 +130,9 @@ profiles {
         params.samplesheet              = 'test_data/qfly/test_samplesheet.csv' // Qfly test data
         params.ref_genome               = 'test_data/qfly/GCA_016617805.2_CM028320.1_50000-99999.fa' // Qfly genome subset to 50-100kb
         params.mito_contig              = 'HQ130030.1'
-        interval_n                      = 10
-        interval_nbreaks                = 1
-        subdivide_intervals             = true
+        params.interval_n               = 10
+        params.interval_nbreaks         = 1
+        params.subdivide_intervals      = true
         params.fastq_chunk_size	      	= 1000
         params.max_memory               = '2.GB'
         params.max_time                 = '10.m'

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,10 +22,10 @@ params {
 
     ///// Interval parameters
     fastq_chunk_size            = 5E6                               // number of reads .fastq files should be split into for mapping to genome
-    interval_size               = 5E6                               // Create genomic intervals of this size for genotyping. Set to -1 to disable
-    interval_n                  = -1                               // Create this many genomic for genotyping. Set to -1 to disable parralel genotyping on
+    interval_splitn             = 100                               // Split genomic intervals on this many N bases
+    interval_n                  = -1                                // Create this many genomic for genotyping. Set to -1 to disable parralel genotyping on
     interval_bed                = null                              // Optional input bed file for included intervals
-    interval_padding            = 1000                              // Optional padding for included intervals
+    interval_padding            = 100                               // Optional padding for included intervals
     exclude_bed                 = null                              // Optional exclusion of certain intervals
     exclude_padding             = 0                                 // Optional padding of exclusion intervals
 

--- a/nextflow/modules/call_variants.nf
+++ b/nextflow/modules/call_variants.nf
@@ -8,6 +8,7 @@ process CALL_VARIANTS {
     input:
     tuple val(sample), path(bam, name: '*sorted.bam'), path(bam_index, name: '*sorted.bam.bai'), val(interval_hash), path(interval_list)
     tuple path(ref_genome), path(genome_index_files)
+    val(interval_padding)
 
     output: 
     tuple val(sample), path("*.g.vcf.gz"), path("*.g.vcf.gz.tbi"), val(interval_hash), path(interval_list),     emit: gvcf_intervals
@@ -25,7 +26,8 @@ process CALL_VARIANTS {
         "${bam}" \
         ${ref_genome} \
         ${interval_hash} \
-        ${interval_list}
+        ${interval_list}\
+        ${interval_padding}
 
     """
 }

--- a/nextflow/modules/create_bed_intervals.nf
+++ b/nextflow/modules/create_bed_intervals.nf
@@ -3,11 +3,11 @@ process CREATE_BED_INTERVALS {
     // tag "-"
     publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
-    module "BEDTools/2.31.1-GCC-13.3.0"
+    module "BEDTools/2.31.1-GCC-13.3.0:GATK/4.6.1.0-GCCcore-13.3.0-Java-21:picard/3.3.0-Java-21"
 
     input:
     tuple path(ref_fasta), path(indexes)
-    val(interval_size)
+    val(interval_splitn)
     val(interval_n)
     path(interval_bed)
     val(interval_padding)
@@ -26,7 +26,7 @@ process CREATE_BED_INTERVALS {
     ### run process script
     bash ${process_script} \
         ${task.cpus} \
-        ${interval_size} \
+        ${interval_splitn} \
         ${interval_n} \
         ${interval_bed} \
         ${interval_padding} \

--- a/nextflow/modules/create_bed_intervals.nf
+++ b/nextflow/modules/create_bed_intervals.nf
@@ -16,7 +16,7 @@ process CREATE_BED_INTERVALS {
     val(mito_contig)
 
     output: 
-    path("*.bed"),              emit: interval_list
+    path("interval_*.bed"),              emit: interval_list
     
     script:
     def process_script = "${process_name}.sh"

--- a/nextflow/modules/create_bed_intervals.nf
+++ b/nextflow/modules/create_bed_intervals.nf
@@ -7,13 +7,17 @@ process CREATE_BED_INTERVALS {
 
     input:
     tuple path(ref_fasta), path(indexes)
-    val(interval_splitn)
     val(interval_n)
+    val(interval_nbreaks)
+    val(subdivide_intervals)
     path(interval_bed)
-    val(interval_padding)
     path(exclude_bed)
     val(exclude_padding)
     val(mito_contig)
+    
+            params.interval_n,
+        params.interval_nbreaks,
+        params.subdivide_intervals,
 
     output: 
     path("*.bed"),              emit: interval_list
@@ -26,10 +30,10 @@ process CREATE_BED_INTERVALS {
     ### run process script
     bash ${process_script} \
         ${task.cpus} \
-        ${interval_splitn} \
         ${interval_n} \
+        ${interval_splitn} \
+        ${subdivide_intervals} \
         ${interval_bed} \
-        ${interval_padding} \
         ${exclude_bed} \
         ${exclude_padding} \
         ${mito_contig} \

--- a/nextflow/modules/create_bed_intervals.nf
+++ b/nextflow/modules/create_bed_intervals.nf
@@ -8,11 +8,12 @@ process CREATE_BED_INTERVALS {
     input:
     tuple path(ref_fasta), path(indexes)
     val(interval_n)
-    val(interval_nbreaks)
-    val(subdivide_intervals)
+    val(interval_break_n)
+    val(interval_break_n_length)
+    val(interval_subdivide)
     path(interval_bed)
-    path(exclude_bed)
-    val(exclude_padding)
+    path(interval_exclude_bed)
+    val(interval_exclude_padding)
     val(mito_contig)
 
     output: 
@@ -27,13 +28,15 @@ process CREATE_BED_INTERVALS {
     bash ${process_script} \
         ${task.cpus} \
         ${interval_n} \
-        ${interval_nbreaks} \
-        ${subdivide_intervals} \
+        ${interval_break_n} \
+        ${interval_break_n_length} \
         ${interval_bed} \
-        ${exclude_bed} \
-        ${exclude_padding} \
+        ${interval_exclude_bed} \
+        ${interval_exclude_padding} \
         ${mito_contig} \
-        ${ref_fasta}
+        ${ref_fasta} \
+        ${interval_subdivide} 
+        
     """
   
 }

--- a/nextflow/modules/create_bed_intervals.nf
+++ b/nextflow/modules/create_bed_intervals.nf
@@ -14,10 +14,6 @@ process CREATE_BED_INTERVALS {
     path(exclude_bed)
     val(exclude_padding)
     val(mito_contig)
-    
-            params.interval_n,
-        params.interval_nbreaks,
-        params.subdivide_intervals,
 
     output: 
     path("*.bed"),              emit: interval_list
@@ -31,7 +27,7 @@ process CREATE_BED_INTERVALS {
     bash ${process_script} \
         ${task.cpus} \
         ${interval_n} \
-        ${interval_splitn} \
+        ${interval_nbreaks} \
         ${subdivide_intervals} \
         ${interval_bed} \
         ${exclude_bed} \

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -21,13 +21,6 @@ workflow GATK_GENOTYPING {
 
     main: 
 
-    // check that params.interval_size is not less than 100k bases
-    // Disabled - this could be covered in documentation
-    //if ( params.interval_size.toFloat() < 1E5 ){
-    //    println ("\n*** ERROR: 'params.interval_size' must be >= 1E5 (100,000 bases) ***\n")
-    //    error()
-    //}
-
     /* 
         Genotype samples individually and jointly
     */
@@ -40,7 +33,8 @@ workflow GATK_GENOTYPING {
     // call variants for single samples across intervals
     CALL_VARIANTS (
         ch_sample_intervals,
-        ch_genome_indexed
+        ch_genome_indexed,
+        params.interval_padding
     )
 
     // group GVCFs by interval 

--- a/nextflow/workflows/skimseq.nf
+++ b/nextflow/workflows/skimseq.nf
@@ -87,10 +87,10 @@ workflow SKIMSEQ {
     } 
 
     // Handle empty intervals for exclude bed
-    if ( params.exclude_bed ){
+    if ( params.interval_exclude_bed ){
         ch_exclude_bed = Channel
             .fromPath (
-                params.exclude_bed, 
+                params.interval_exclude_bed, 
                 checkIfExists: true
             )
     } else {
@@ -101,11 +101,12 @@ workflow SKIMSEQ {
     CREATE_BED_INTERVALS (
         ch_genome_indexed,
         params.interval_n,
-        params.interval_nbreaks,
-        params.subdivide_intervals,
+        params.interval_break_n,
+        params.interval_break_n_length,
+        params.interval_subdivide,
         ch_interval_bed,
         ch_exclude_bed,
-        params.exclude_padding,
+        params.interval_exclude_padding,
         params.mito_contig
     )
 

--- a/nextflow/workflows/skimseq.nf
+++ b/nextflow/workflows/skimseq.nf
@@ -100,7 +100,7 @@ workflow SKIMSEQ {
     // create groups of genomic intervals for parallel genotyping
     CREATE_BED_INTERVALS (
         ch_genome_indexed,
-        params.interval_size,
+        params.interval_splitn,
         params.interval_n,
         ch_interval_bed,
         params.interval_padding,

--- a/nextflow/workflows/skimseq.nf
+++ b/nextflow/workflows/skimseq.nf
@@ -100,8 +100,9 @@ workflow SKIMSEQ {
     // create groups of genomic intervals for parallel genotyping
     CREATE_BED_INTERVALS (
         ch_genome_indexed,
-        params.interval_splitn,
         params.interval_n,
+        params.interval_nbreaks,
+        params.subdivide_intervals,
         ch_interval_bed,
         params.interval_padding,
         ch_exclude_bed,

--- a/nextflow/workflows/skimseq.nf
+++ b/nextflow/workflows/skimseq.nf
@@ -104,7 +104,6 @@ workflow SKIMSEQ {
         params.interval_nbreaks,
         params.subdivide_intervals,
         ch_interval_bed,
-        params.interval_padding,
         ch_exclude_bed,
         params.exclude_padding,
         params.mito_contig


### PR DESCRIPTION
This addresses #69 and is relevent to #64 

- If `interval_break_n = true` (**defaullt**), a list of within-contig 'breakpoints' is made from all runs of N's larger than `interval_break_n_length` (**default 100bp**). This is then used for an initial split of longer contigs into short genotypable regions. 

- The short genotypable regions are aggregated into groups of approximately even bp length for parallel processing, with the `interval_n` (**default 100**) parameter controlling the number of groups created and resulting number of parallel GATK processes. This parameter is now the primary control for parallel processing with GATK. 

- `interval_subdivide` (**default true**) is used to automatically subdivide intervals further to ensure there are an even number of bases per interval-group for parallel processing. Setting it to false will ensure that intervals never start and end in an alignable & potentially variant containing region or base, but could cause mismatched total size of interval groups for high quality genomes with few natural breakpoints

- `interval_size` is removed, as `interval_subdivide = true` more effectively normalises the number of bases analysed in each genomic interval / parallel process. This change means that larger genomes will have larger intervals than smaller genomes when `interval_size` is left at default, but this shouldnt really affect resource usage for `HaplotypeCaller` as it doesnt operate on the whole interval at once with memory instead scaling with read-depth & number of haplotypes.

- If the user really needs intervals to be a specific bp length for some other analytical reason, they can provide a pre-created `interval_bed` with their custom interval design and set `interval_subdivide = false` and `interval_break_n = false` to prevent any further splitting.




