### PR TITLE
Variant calling changes

### DIFF
--- a/bin/call_variants.sh
+++ b/bin/call_variants.sh
@@ -12,6 +12,10 @@ set -u
 # $8 = interval_padding
 # $9 = exclude_bed
 # $10 = exclude_padding
+# $11 = hc_min_pruning
+# $12 = hc_min_dangling_length
+# $13 = hc_max_reads_startpos
+# $14 = ploidy
 
 # Create list of bams to be processed
 echo ${4} | tr ' ' '\n' > bam.list
@@ -23,10 +27,13 @@ gatk --java-options "-Xmx${2}G" HaplotypeCaller \
     -L $7 \
     -O ${3}.${6}.g.vcf.gz \
     --native-pair-hmm-threads ${1} \
-    --min-base-quality-score 15 \
-    --min-pruning 0 \
     --interval-padding ${8} \
     --exclude-intervals ${9} \
     --interval-exclusion-padding ${10} \
     --interval-merging-rule ALL \
+    --min-base-quality-score 15 \
+    --min-pruning ${11} \
+    --min-dangling-branch-length ${12} \
+    --max-reads-per-alignment-start ${13} \
+    -ploidy ${14} \
     -ERC GVCF

--- a/bin/filter_invariant.sh
+++ b/bin/filter_invariant.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+set -u
+## args are the following:
+# $1 = cpus 
+# $2 = vcf
+# $3 = inv_dp_min
+# $4 = inv_dp_max
+# $5 = indel_custom_flags
+# $6 = max_missing
+# $7 = mask_bed
+
+# Make sure mask file is sorted and unique
+# TODO: Work out why the input mask is duplicated in the first place
+bedtools sort -i ${7} | uniq > vcf_masks.bed
+
+# Index mask bed for use in filtering
+gatk IndexFeatureFile \
+     -I vcf_masks.bed
+     
+# Subset to NO_VARIATION
+gatk SelectVariants \
+	--verbosity ERROR \
+	-V $2 \
+	-select-type NO_VARIATION \
+	-O inv.vcf.gz
+
+# Extract invariant quality scores pre filtering
+gatk VariantsToTable \
+	--verbosity ERROR \
+	-V inv.vcf.gz \
+	-F CHROM -F POS -F QUAL -F DP \
+	-O inv.table
+
+pigz -p${1} inv.table
+
+# Hard-filter invariant
+if [[ ${14} == "none" ]]; then
+	# use individual parameters
+	gatk VariantFiltration \
+		--verbosity ERROR \
+		-V inv.vcf.gz \
+		-filter "DP < ${3}" --filter-name "DPmin" \
+		-filter "DP > ${4}" --filter-name "DPmax" \
+		--mask vcf_masks.bed --mask-name Mask \
+		-O inv_tmp.vcf.gz
+else
+	# use custom filters
+	gatk VariantFiltration \
+		--verbosity ERROR \
+		-V inv.vcf.gz \
+		${5} \
+		--mask vcf_masks.bed --mask-name Mask \
+		-O inv_tmp.vcf.gz
+fi
+
+# Transform filtered genotypes to nocall and keep only those with <5% missing data
+gatk SelectVariants \
+	--verbosity ERROR \
+	-V inv_tmp.vcf.gz \
+	--set-filtered-gt-to-nocall \
+	--max-nocall-fraction ${6} \
+	--exclude-filtered \
+	-O inv_filtered_tmp.vcf.gz 
+
+# Sort invariant vcf
+gatk SortVcf \
+    -I inv_filtered_tmp.vcf.gz \
+    -O inv_filtered.vcf.gz 
+
+# Extract invariant quality scores post filtering
+gatk VariantsToTable \
+	--verbosity ERROR \
+	-V inv_filtered.vcf.gz \
+	-F CHROM -F POS -F QUAL -F DP \
+	-O inv_filtered.table
+
+pigz -p${1} inv_filtered.table

--- a/bin/filter_invariant.sh
+++ b/bin/filter_invariant.sh
@@ -35,7 +35,7 @@ gatk VariantsToTable \
 pigz -p${1} inv.table
 
 # Hard-filter invariant
-if [[ ${14} == "none" ]]; then
+if [[ ${5} == "none" ]]; then
 	# use individual parameters
 	gatk VariantFiltration \
 		--verbosity ERROR \

--- a/bin/genomicsdb_import.sh
+++ b/bin/genomicsdb_import.sh
@@ -9,7 +9,10 @@ set -u
 # $5 = interval_list
 
 # Mem for genomicsdb must be a few GB less than assigned mem
-genomicsdb_mem="$((${2}-2))"
+genomicsdb_mem=$(( ${2} - 2 ))        # leave 2 GB head-room
+if (( genomicsdb_mem < 1 )); then    # clamp to ≥1 GB
+    genomicsdb_mem=1
+fi
 
 ## NOTE: .g.vcf files and their .tbi indexes are staged 
 

--- a/bin/genomicsdb_import.sh
+++ b/bin/genomicsdb_import.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+set -u
+## args are the following:
+# $1 = cpus 
+# $2 = memory
+# $3 = ref genome
+# $4 = interval hash
+# $5 = interval_list
+
+# Mem for genomicsdb must be a few GB less than assigned mem
+genomicsdb_mem="$((${2}-2))"
+
+## NOTE: .g.vcf files and their .tbi indexes are staged 
+
+# Create sample map file
+vcf=$(ls *.g.vcf.gz | sort | uniq )
+sample_id=$(echo "$vcf" | cut -f1 -d '.')
+paste -d '\t' <(echo "$sample_id") <(echo "$vcf") > ${4}.sample_map
+
+# Import gvcfs into genomicsdb
+gatk --java-options "-Xmx${genomicsdb_mem}G -Xms${genomicsdb_mem}g"  GenomicsDBImport \
+    --genomicsdb-workspace-path ${4} \
+    --batch-size 0 \
+    -L ${5} \
+    --sample-name-map ${4}.sample_map \
+    --tmp-dir /tmp \
+    --merge-input-intervals true \
+    --interval-merging-rule ALL \
+    --bypass-feature-reader \
+    --max-num-intervals-to-import-in-parallel ${1} \
+    --reader-threads 1

--- a/bin/joint_genotype.sh
+++ b/bin/joint_genotype.sh
@@ -4,7 +4,7 @@ set -u
 ## args are the following:
 # $1 = cpus 
 # $2 = memory
-# $3 = gvcf
+# $3 = genomicsDB
 # $4 = ref_genome
 # $5 = interval hash
 # $6 = interval_list
@@ -12,9 +12,10 @@ set -u
 # joint genotype variant sites only
 gatk --java-options "-Xmx${2}G" GenotypeGVCFs \
     -R ${4} \
-    -V ${3} \
+    -V gendb://${3} \
     -L ${6} \
     -O ${5}.vcf.gz \
-    --use-posteriors-to-calculate-qual true \
-    --genotype-assignment-method USE_POSTERIORS_ANNOTATION \
     --tmp-dir /tmp
+
+#    --use-posteriors-to-calculate-qual true \
+#    --genotype-assignment-method USE_POSTERIORS_ANNOTATION \

--- a/bin/joint_genotype.sh
+++ b/bin/joint_genotype.sh
@@ -11,7 +11,7 @@ set -u
 # $7 = output_invariant
 
 # Whether all sites should be exported or not 
-if [[ ${171} == "true" ]];   then FORCE_OUTPUT_INTERVALS="--force-output-intervals ${6}";        else FORCE_OUTPUT_INTERVALS=""; fi
+if [[ ${7} == "true" ]];   then FORCE_OUTPUT_INTERVALS="--force-output-intervals ${6}";        else FORCE_OUTPUT_INTERVALS=""; fi
 
 
 # joint genotype variant sites only

--- a/bin/joint_genotype.sh
+++ b/bin/joint_genotype.sh
@@ -8,6 +8,11 @@ set -u
 # $4 = ref_genome
 # $5 = interval hash
 # $6 = interval_list
+# $7 = output_invariant
+
+# Whether all sites should be exported or not 
+if [[ ${171} == "true" ]];   then FORCE_OUTPUT_INTERVALS="--force-output-intervals ${6}";        else FORCE_OUTPUT_INTERVALS=""; fi
+
 
 # joint genotype variant sites only
 gatk --java-options "-Xmx${2}G" GenotypeGVCFs \
@@ -15,6 +20,9 @@ gatk --java-options "-Xmx${2}G" GenotypeGVCFs \
     -V gendb://${3} \
     -L ${6} \
     -O ${5}.vcf.gz \
+    --merge-input-intervals true \
+    --only-output-calls-starting-in-intervals \
+    $FORCE_OUTPUT_INTERVALS \
     --tmp-dir /tmp
 
 #    --use-posteriors-to-calculate-qual true \

--- a/bin/merge_filtered.sh
+++ b/bin/merge_filtered.sh
@@ -5,9 +5,11 @@ set -u
 # $1 = cpus 
 # $2 = snp_vcf
 # $3 = indel_vcf
+# $4 = invariant_vcf
 
 gatk MergeVcfs \
 	-I $2 \
 	-I $3 \
+	-I $4 \
 	-O combined_filtered.vcf.gz
 

--- a/bin/population_callset.sh
+++ b/bin/population_callset.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+set -u
+## args are the following:
+# $1 = cpus 
+# $2 = memory
+# $3 = genomicsDB
+# $4 = ref_genome
+# $5 = interval hash
+# $6 = interval_list
+
+# joint genotype variant sites only
+gatk --java-options "-Xmx${2}G" SelectVariants \
+    -R ${4} \
+    -V gendb://${3} \
+    -L ${6} \
+    -O ${5}.popcalls.vcf.gz \
+    --sites-only-vcf-output
+    --tmp-dir /tmp

--- a/nextflow.config
+++ b/nextflow.config
@@ -65,6 +65,12 @@ params {
     ///// BAM processing (Samtools) parameters
     bam_rmdup                  = true                                // Remove duplicates from bam files; boolean
 
+    ///// Variant calling (GATK) parameters
+    hc_min_pruning              = 2                                 // Minimum support to not prune paths in the assembly graph. Setting to 1 increases sensitivity for low-coverage data; integer
+    hc_min_dangling_length      = 4                                 // Minimum length of a dangling branch to attempt recovery. Smaller number increases sensitivity at expense of false positives; integer
+    hc_max_reads_startpos       = 50                                // Maximum number of reads to retain per alignment start position. Increase if doing deep targetted sequencing; integer
+    ploidy                      = 2                                 // Ploidy of the samples; integer
+    output_invariant            = false                             // Whether to output invariant sites; logical
 
     ///// SNP variant filtering (GATK) parameters
     snp_qd                      = 2.0                               // filter SNPs with QD (quality by depth) < value; float
@@ -92,7 +98,6 @@ params {
     indel_custom_flags          = "none"                            // custom GATK filtering flags for indels, passed as a single string, overrides all other indel filters; quoted string
 
     ///// invariant site filtering (GATK) parameters
-    output_invariant            = false                             // Whether to output invariant sites; logical
     inv_dp_min                  = 6                                 // filter indels with DP (depth) < value; integer
     inv_dp_max                  = 1500                              // filter indels with DP (depth) > value; integer
     inv_custom_flags            = "none"                            // custom GATK filtering flags for invariants, passed as a single string, overrides all other invariant filters; quoted string

--- a/nextflow.config
+++ b/nextflow.config
@@ -319,6 +319,11 @@ process {
         time    = { time_scale ( 6.h,   task.attempt ) }
     }
     withName: GENOMICSDB_IMPORT {
+        cpus    = { cpu_scale  ( 4,     task.attempt ) }
+        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+        time    = { time_scale ( 6.h,   task.attempt ) }
+    }
+    withName: POPULATION_CALLSET {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }
         time    = { time_scale ( 6.h,   task.attempt ) }

--- a/nextflow.config
+++ b/nextflow.config
@@ -314,14 +314,9 @@ process {
     }
     
     
-    //GATK Resources
+    //GATK_genotyping subworkflow Resources
     withName: CALL_VARIANTS {
         cpus    = { cpu_scale  ( 2,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
-        time    = { time_scale ( 6.h,   task.attempt ) }
-    }
-    withName: COMBINE_GVCFS {
-        cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }
         time    = { time_scale ( 6.h,   task.attempt ) }
     }
@@ -330,22 +325,17 @@ process {
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }
         time    = { time_scale ( 6.h,   task.attempt ) }
     }
-    withName: POPULATION_CALLSET {
-        cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
-        time    = { time_scale ( 6.h,   task.attempt ) }
-    }
-    withName: GENOTYPE_POSTERIORS {
-        cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
-        time    = { time_scale ( 2.h,   task.attempt ) }
-    }
     withName: JOINT_GENOTYPE {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }
         time    = { time_scale ( 2.h,   task.attempt ) }
     }    
-    
+    withName: MERGE_VCFS {
+        cpus    = { cpu_scale  ( 1,     task.attempt ) }
+        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+        time    = { time_scale ( 1.h,   task.attempt ) }
+    }  
+
     // filter_variants subworkflow resources
     withName: FILTER_INDELS {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
@@ -356,22 +346,12 @@ process {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }
-    }
-    withName: MERGE_VCFS {
-        cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
-        time    = { time_scale ( 1.h,   task.attempt ) }
-    }   
+    } 
     withName: MERGE_FILTERED {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }
     } 
-    withName: CREATE_BEAGLE {
-        cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
-        time    = { time_scale ( 30.m,   task.attempt ) }
-    }
     withName: VCF_STATS {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }
@@ -390,7 +370,29 @@ process {
         time    = { time_scale ( 2.h,   task.attempt ) }
     }   
 
+    //Prob genotyping resources (currently disabled)
+    //withName: POPULATION_CALLSET {
+    //    cpus    = { cpu_scale  ( 1,     task.attempt ) }
+    //    memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+    //    time    = { time_scale ( 6.h,   task.attempt ) }
+    //}
+    //withName: GENOTYPE_POSTERIORS {
+    //    cpus    = { cpu_scale  ( 1,     task.attempt ) }
+    //    memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+    //    time    = { time_scale ( 2.h,   task.attempt ) }
+    //}
+    //withName: CREATE_BEAGLE {
+    //    cpus    = { cpu_scale  ( 1,     task.attempt ) }
+    //    memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+    //    time    = { time_scale ( 30.m,   task.attempt ) }
+    //}
+
     //Depreciated process resources
+    //withName: COMBINE_GVCFS {
+    //    cpus    = { cpu_scale  ( 1,     task.attempt ) }
+    //    memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+    //    time    = { time_scale ( 6.h,   task.attempt ) }
+    //}
     //withName: CONVERT_INTERVALS {
     //    cpus    = { cpu_scale  ( 1,     task.attempt ) }
     //    memory  = { mem_scale  ( 2.GB,  task.attempt ) }

--- a/nextflow.config
+++ b/nextflow.config
@@ -318,6 +318,11 @@ process {
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }
         time    = { time_scale ( 6.h,   task.attempt ) }
     }
+    withName: GENOMICSDB_IMPORT {
+        cpus    = { cpu_scale  ( 1,     task.attempt ) }
+        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+        time    = { time_scale ( 6.h,   task.attempt ) }
+    }
     withName: GENOTYPE_POSTERIORS {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }

--- a/nextflow.config
+++ b/nextflow.config
@@ -91,9 +91,15 @@ params {
     indel_dp_max                = 1500                              // filter indels with DP (depth) > value; integer
     indel_custom_flags          = "none"                            // custom GATK filtering flags for indels, passed as a single string, overrides all other indel filters; quoted string
 
+    ///// invariant site filtering (GATK) parameters
+    output_invariant            = false                             // Whether to output invariant sites; logical
+    inv_dp_min                  = 6                                 // filter indels with DP (depth) < value; integer
+    inv_dp_max                  = 1500                              // filter indels with DP (depth) > value; integer
+    inv_custom_flags            = "none"                            // custom GATK filtering flags for invariants, passed as a single string, overrides all other invariant filters; quoted string
+
     ///// general filtering (GATK)
     max_missing                 = 0.05                              // maximum fraction of missing data to accept when filtering variants; float/proportion
-
+    
     ///// debugging options
     debug_mode                  = false 
     rdata                       = false                             // save all data/objects from process-level R sessions as .RData files in work dir; boolean
@@ -154,6 +160,7 @@ profiles {
         params.interval_subdivide_at_masks  = true
         params.include_bed              = 'test_data/qfly/include_interval.bed'
         params.exclude_bed              = 'test_data/qfly/exclude_interval.bed'
+        params.output_invariant         = true
         params.fastq_chunk_size	      	= 1000
         params.max_memory               = '2.GB'
         params.max_time                 = '10.m'

--- a/nextflow/modules/call_variants.nf
+++ b/nextflow/modules/call_variants.nf
@@ -11,6 +11,10 @@ process CALL_VARIANTS {
     val(interval_padding)
     path(exclude_bed)
     val(exclude_padding)
+    val(hc_min_pruning)
+    val(hc_min_dangling_length)
+    val(hc_max_reads_startpos)
+    val(ploidy)
 
     output: 
     tuple val(sample), path("*.g.vcf.gz"), path("*.g.vcf.gz.tbi"), val(interval_hash), path(interval_bed),     emit: gvcf_intervals
@@ -31,7 +35,11 @@ process CALL_VARIANTS {
         ${interval_bed} \
         ${interval_padding} \
         "${exclude_bed}" \
-        ${exclude_padding}
+        ${exclude_padding} \
+        ${hc_min_pruning} \
+        ${hc_min_dangling_length} \
+        ${hc_max_reads_startpos} \
+        ${ploidy}
         
     """
 }

--- a/nextflow/modules/filter_invariant.nf
+++ b/nextflow/modules/filter_invariant.nf
@@ -1,0 +1,34 @@
+process FILTER_INVARIANT {
+    def process_name = "filter_invariant"    
+    // tag "-"
+    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    // container "jackscanlan/piperline-multi:0.0.1"
+    module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
+
+    input:
+    tuple path(vcf), path(vcf_tbi)
+    tuple val(inv_dp_min), val(inv_dp_max), val(inv_custom_flags)
+    val(max_missing)
+    path(mask_bed)
+
+    output: 
+    tuple path("inv_filtered.vcf.gz"), path("inv_filtered.vcf.gz.tbi"),   emit: vcf
+    path("*.table.gz"),                                                   emit: tables
+    
+    script:
+    def process_script = "${process_name}.sh"
+    """
+    #!/usr/bin/env bash
+     
+    ### run process script
+    bash ${process_script} \
+        ${task.cpus} \
+        ${vcf} \
+        "${inv_dp_min}" \
+        "${inv_dp_max}" \
+        "${inv_custom_flags}" \
+        ${max_missing} \
+        ${mask_bed}
+
+    """
+}

--- a/nextflow/modules/genomicsdb_import.nf
+++ b/nextflow/modules/genomicsdb_import.nf
@@ -1,0 +1,29 @@
+process GENOMICSDB_IMPORT {
+    def process_name = "genomicsdb_import"    
+    // tag "-"
+    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    // container "jackscanlan/piperline-multi:0.0.1"
+    module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
+
+    input:
+    tuple val(interval_hash), path(interval_list), path(gvcf), path(tbi)
+    tuple path(ref_genome), path(genome_index_files)
+
+    output: 
+    tuple val(interval_hash), path(interval_list), path("*.combined.g.vcf.gz"), path("*.combined.g.vcf.gz.tbi"),      emit: gvcf_intervals
+    
+    script:
+    def process_script = "${process_name}.sh"
+    """
+    #!/usr/bin/env bash
+    
+    ### run process script
+    bash ${process_script} \
+        ${task.cpus} \
+        ${task.memory.giga} \
+        ${ref_genome} \
+        ${interval_hash} \
+        ${interval_list}
+
+    """
+}

--- a/nextflow/modules/genomicsdb_import.nf
+++ b/nextflow/modules/genomicsdb_import.nf
@@ -10,7 +10,7 @@ process GENOMICSDB_IMPORT {
     tuple path(ref_genome), path(genome_index_files)
 
     output: 
-    tuple val(interval_hash), path(interval_list), path("*.combined.g.vcf.gz"), path("*.combined.g.vcf.gz.tbi"),      emit: gvcf_intervals
+    tuple val(interval_hash), path(interval_list), path("$interval_hash"),      emit: genomicsdb
     
     script:
     def process_script = "${process_name}.sh"

--- a/nextflow/modules/joint_genotype.nf
+++ b/nextflow/modules/joint_genotype.nf
@@ -7,6 +7,7 @@ process JOINT_GENOTYPE {
     input:
     tuple val(interval_hash), path(interval_list), path(genomicsdb)
     tuple path(ref_genome), path(genome_index_files)
+    val(output_invariant)
 
     output: 
     tuple path("*.vcf.gz"), path("*.vcf.gz.tbi"),       emit: vcf
@@ -23,7 +24,8 @@ process JOINT_GENOTYPE {
         ${genomicsdb} \
         ${ref_genome} \
         ${interval_hash} \
-        ${interval_list}
+        ${interval_list} \
+        ${output_invariant}
 
     """
 }

--- a/nextflow/modules/joint_genotype.nf
+++ b/nextflow/modules/joint_genotype.nf
@@ -5,7 +5,7 @@ process JOINT_GENOTYPE {
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 
     input:
-    tuple val(interval_hash), path(interval_list), path(gvcf), path(gvcf_tbi)
+    tuple val(interval_hash), path(interval_list), path(genomicsdb)
     tuple path(ref_genome), path(genome_index_files)
 
     output: 
@@ -20,7 +20,7 @@ process JOINT_GENOTYPE {
     bash ${process_script} \
         ${task.cpus} \
         ${task.memory.giga} \
-        ${gvcf} \
+        ${genomicsdb} \
         ${ref_genome} \
         ${interval_hash} \
         ${interval_list}

--- a/nextflow/modules/merge_filtered.nf
+++ b/nextflow/modules/merge_filtered.nf
@@ -8,6 +8,7 @@ process MERGE_FILTERED {
     input:
     tuple path(snp_vcf), path(snp_vcf_tbi)
     tuple path(indel_vcf), path(indel_vcf_tbi)
+    tuple path(invariant_vcf), path(invariant_vcf_tbi)
 
     output: 
     tuple path("combined_filtered.vcf.gz"), path("combined_filtered.vcf.gz.tbi"),   emit: vcf
@@ -21,7 +22,8 @@ process MERGE_FILTERED {
     bash ${process_script} \
         ${task.cpus} \
         ${snp_vcf} \
-        ${indel_vcf}
+        ${indel_vcf} \
+        ${invariant_vcf}
 
     """
 }

--- a/nextflow/modules/population_callset.nf
+++ b/nextflow/modules/population_callset.nf
@@ -1,0 +1,29 @@
+process POPULATION_CALLSET {
+    def process_name = "population_callset"    
+    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    // container "jackscanlan/piperline-multi:0.0.1"
+    module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
+
+    input:
+    tuple val(interval_hash), path(interval_list), path(genomicsdb)
+    tuple path(ref_genome), path(genome_index_files)
+
+    output: 
+    tuple path("*.popcalls.vcf.gz"), path("*.popcalls.vcf.gz.tbi"),       emit: population_callset
+    
+    script:
+    def process_script = "${process_name}.sh"
+    """
+    #!/usr/bin/env bash
+      
+    ### run process script
+    bash ${process_script} \
+        ${task.cpus} \
+        ${task.memory.giga} \
+        ${genomicsdb} \
+        ${ref_genome} \
+        ${interval_hash} \
+        ${interval_list}
+
+    """
+}

--- a/nextflow/subworkflows/filter_variants.nf
+++ b/nextflow/subworkflows/filter_variants.nf
@@ -68,10 +68,28 @@ workflow FILTER_VARIANTS {
         ch_mask_bed_vcf
     )
 
+    // collect invariant filtering parameters into a single list
+    Channel.of (     
+        params.inv_dp_min,      
+        params.inv_dp_max,      
+        params.inv_custom_flags,
+    )
+    .collect ( sort: false )
+    .set { ch_inv_filters }
+
+    // filter indels
+    FILTER_INVARIANT (
+        ch_vcf,
+        ch_inv_filters,
+        params.max_missing,
+        ch_mask_bed_vcf
+    )
+
     // merge filtered SNPs and indels together into one file
     MERGE_FILTERED (
         FILTER_SNPS.out.vcf,
-        FILTER_INDELS.out.vcf
+        FILTER_INDELS.out.vcf,
+        FILTER_INVARIANT.out.vcf
     )
 
     // Calculate VCF statistics

--- a/nextflow/subworkflows/filter_variants.nf
+++ b/nextflow/subworkflows/filter_variants.nf
@@ -5,6 +5,7 @@
 //// import modules
 include { FILTER_INDELS                                                 } from '../modules/filter_indels'
 include { FILTER_SNPS                                                 } from '../modules/filter_snps'
+include { FILTER_INVARIANT                                                 } from '../modules/filter_invariant'
 include { MERGE_FILTERED                                                 } from '../modules/merge_filtered'
 include { VCF_STATS                                                } from '../modules/vcf_stats'
 

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -79,10 +79,10 @@ workflow GATK_GENOTYPING {
         .set { ch_gvcf_interval }
 
     // combine GVCFs into one file per interval
-    COMBINE_GVCFS (
-        ch_gvcf_interval,
-        ch_genome_indexed
-    )
+    //COMBINE_GVCFS (
+    //    ch_gvcf_interval,
+    //    ch_genome_indexed
+    //)
 
     // Import GVCFs into a genomicsDB per Interval
     GENOMICSDB_IMPORT (
@@ -95,9 +95,11 @@ workflow GATK_GENOTYPING {
     //    COMBINE_GVCFS.out.gvcf_intervals
     //)
 
+    // TODO: Add POPULATION_CALLSET process here
+
     // call genotypes at variant sites
     JOINT_GENOTYPE (
-        GENOMICSDB_IMPORT.out.genomisdb,
+        GENOMICSDB_IMPORT.out.genomicsdb,
         ch_genome_indexed
     )
 

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -10,6 +10,7 @@ include { GENOTYPE_POSTERIORS                                    } from '../modu
 include { JOINT_GENOTYPE                                         } from '../modules/joint_genotype' 
 include { MERGE_VCFS                                             } from '../modules/merge_vcfs' 
 include { CREATE_BED_INTERVALS                                   } from '../modules/create_bed_intervals'
+include { GENOMICSDB_IMPORT                                      } from '../modules/genomicsdb_import' 
 
 
 
@@ -44,17 +45,17 @@ workflow GATK_GENOTYPING {
         params.interval_subdivide_balanced
     )
 
-    // create intervals channel, with one interval_list file per element
+    // create intervals channel, with one interval_bed file per element
     CREATE_BED_INTERVALS.out.interval_bed
         .flatten()
-        // get hash from interval_list name as element to identify intervals
-        .map { interval_list ->
-            def interval_hash = interval_list.getFileName().toString().split("\\.")[0]
-            [ interval_hash, interval_list ] }
+        // get hash from interval_bed name as element to identify intervals
+        .map { interval_bed ->
+            def interval_hash = interval_bed.getFileName().toString().split("\\.")[0]
+            [ interval_hash, interval_bed ] }
         .set { ch_interval_bed }
         
 
-    // combine sample-level bams with each interval_list file and interval hash
+    // combine sample-level bams with each interval_bed file and interval hash
     ch_sample_bam
         .combine ( ch_interval_bed )
         .set { ch_sample_intervals }
@@ -70,15 +71,21 @@ workflow GATK_GENOTYPING {
 
     // group GVCFs by interval 
     CALL_VARIANTS.out.gvcf_intervals
-        .map { sample, gvcf, tbi, interval_hash, interval_list -> [ interval_hash, gvcf, tbi ] }
+        .map { sample, gvcf, tbi, interval_hash, interval_bed -> [ interval_hash, gvcf, tbi ] }
         .groupTuple ( by: 0 )
         // join to get back interval_file
         .join ( ch_interval_bed, by: 0 )
-        .map { interval_hash, gvcf, tbi, interval_list -> [ interval_hash, interval_list, gvcf, tbi ] }
+        .map { interval_hash, gvcf, tbi, interval_bed -> [ interval_hash, interval_bed, gvcf, tbi ] }
         .set { ch_gvcf_interval }
 
     // combine GVCFs into one file per interval
     COMBINE_GVCFS (
+        ch_gvcf_interval,
+        ch_genome_indexed
+    )
+
+    // Import GVCFs into a genomicsDB per Interval
+    GENOMICSDB_IMPORT (
         ch_gvcf_interval,
         ch_genome_indexed
     )

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -105,7 +105,8 @@ workflow GATK_GENOTYPING {
     // call genotypes at variant sites
     JOINT_GENOTYPE (
         GENOMICSDB_IMPORT.out.genomicsdb,
-        ch_genome_indexed
+        ch_genome_indexed,
+        params.output_invariant
     )
 
     // collect .vcfs into a single element

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -91,13 +91,13 @@ workflow GATK_GENOTYPING {
     )
 
     // calculate genotype posteriors over each genomic interval
-    GENOTYPE_POSTERIORS (
-        COMBINE_GVCFS.out.gvcf_intervals
-    )
+    //GENOTYPE_POSTERIORS (
+    //    COMBINE_GVCFS.out.gvcf_intervals
+    //)
 
     // call genotypes at variant sites
     JOINT_GENOTYPE (
-        GENOTYPE_POSTERIORS.out.gvcf_intervals,
+        GENOMICSDB_IMPORT.out.genomisdb,
         ch_genome_indexed
     )
 
@@ -112,9 +112,9 @@ workflow GATK_GENOTYPING {
     )
 
     // get just posterior .g.vcfs from channel
-    GENOTYPE_POSTERIORS.out.gvcf_intervals
-        .map { interval_hash, interval_list, gvcf, gvcf_tbi -> [ gvcf, gvcf_tbi ] }
-        .set { ch_posteriors }
+    //GENOTYPE_POSTERIORS.out.gvcf_intervals
+    //    .map { interval_hash, interval_list, gvcf, gvcf_tbi -> [ gvcf, gvcf_tbi ] }
+    //    .set { ch_posteriors }
 
     // create beagle file from .g.vcf files with posteriors
     /// NOTE: Could move this to an ANGSD-specific workflow
@@ -127,7 +127,7 @@ workflow GATK_GENOTYPING {
 
     emit: 
     vcf = MERGE_VCFS.out.vcf
-    posteriors = ch_posteriors
+    //posteriors = ch_posteriors
 
 
 }

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -97,10 +97,10 @@ workflow GATK_GENOTYPING {
     //)
 
     // Extract population callset from genomicsdb
-    POPULATION_CALLSET (
-        GENOMICSDB_IMPORT.out.genomicsdb,
-        ch_genome_indexed
-    )
+    //POPULATION_CALLSET (
+    //    GENOMICSDB_IMPORT.out.genomicsdb,
+    //    ch_genome_indexed
+    //)
 
     // call genotypes at variant sites
     JOINT_GENOTYPE (

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -11,6 +11,7 @@ include { JOINT_GENOTYPE                                         } from '../modu
 include { MERGE_VCFS                                             } from '../modules/merge_vcfs' 
 include { CREATE_BED_INTERVALS                                   } from '../modules/create_bed_intervals'
 include { GENOMICSDB_IMPORT                                      } from '../modules/genomicsdb_import' 
+include { POPULATION_CALLSET                                     } from '../modules/population_callset' 
 
 
 
@@ -95,7 +96,11 @@ workflow GATK_GENOTYPING {
     //    COMBINE_GVCFS.out.gvcf_intervals
     //)
 
-    // TODO: Add POPULATION_CALLSET process here
+    // Extract population callset from genomicsdb
+    POPULATION_CALLSET (
+        GENOMICSDB_IMPORT.out.genomicsdb,
+        ch_genome_indexed
+    )
 
     // call genotypes at variant sites
     JOINT_GENOTYPE (

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -62,7 +62,11 @@ workflow GATK_GENOTYPING {
         ch_genome_indexed,
         params.interval_padding,
         ch_mask_bed_gatk, 
-        params.exclude_padding
+        params.exclude_padding,
+        params.hc_min_pruning,
+        params.hc_min_dangling_length,
+        params.hc_max_reads_startpos,
+        params.ploidy
     )
 
     // group GVCFs by interval 

--- a/nextflow/subworkflows/prob_genotyping.nf
+++ b/nextflow/subworkflows/prob_genotyping.nf
@@ -1,0 +1,57 @@
+/*
+    Genotype samples using GATK
+*/
+
+//// import modules
+include { CREATE_BEAGLE                                          } from '../modules/create_beagle' 
+include { GENOTYPE_POSTERIORS                                    } from '../modules/genotype_posteriors' 
+include { MERGE_VCFS                                             } from '../modules/merge_vcfs' 
+include { POPULATION_CALLSET                                     } from '../modules/population_callset' 
+
+
+
+workflow GATK_GENOTYPING {
+
+    take:
+    ch_sample_bam
+    ch_genome_indexed
+    ch_include_bed
+    ch_mask_bed_gatk
+
+    main: 
+
+    /* 
+        Probablistic genotyping
+    */
+    
+    // calculate genotype posteriors over each genomic interval
+    //GENOTYPE_POSTERIORS (
+    //    COMBINE_GVCFS.out.gvcf_intervals
+    //)
+
+    // Extract population callset from genomicsdb
+    //POPULATION_CALLSET (
+    //    GENOMICSDB_IMPORT.out.genomicsdb,
+    //    ch_genome_indexed
+    //)
+
+    // get just posterior .g.vcfs from channel
+    //GENOTYPE_POSTERIORS.out.gvcf_intervals
+    //    .map { interval_hash, interval_list, gvcf, gvcf_tbi -> [ gvcf, gvcf_tbi ] }
+    //    .set { ch_posteriors }
+
+    // create beagle file from .g.vcf files with posteriors
+    /// NOTE: Could move this to an ANGSD-specific workflow
+    
+    //Disabled for now - will be handled by supplementary scripts that need a beagle file
+    //CREATE_BEAGLE (
+    //    ch_posteriors,
+    //    ch_genome_indexed
+    //)
+
+    emit: 
+    vcf = MERGE_VCFS.out.vcf
+    //posteriors = ch_posteriors
+
+
+}


### PR DESCRIPTION
This PR makes changes to the GATK variant calling & filtering workflow:

- Added `hc_min_pruning` `hc_min_dangling_length` `hc_max_reads_startpos` `ploidy` parameters to allow for more control of `GATK HaplotypeCaller`. Resolves #63

- `COMBINE_GVCFS` has been replaced with `GENOMICSDB_IMPORT` which is much more scalable for hundreds of samples. Resolves #72

- Added option to include invariant (hom ref) sites in outputs. This is controlled by new parameter `output_invariant` (**default false**). Some basic filtering is also available for invariant sites through `inv_dp_min`, `inv_dp_max`, and `inv_custom_flags` parameters. Resolves #33 

- General process for `gatk_genotyping` subworkflow has been simplified, it now goes `call_variants` > `import_genomicsdb` > `joint_genotype` > `merge_vcfs`. This aligns with current GATK best practice workflow. `calculate_posteriors` was redundant in this context as `GATK GenotypeGVCFs` handles population level allele frequency priors internally (for variant sites at least).

- The previous `calculate_posteriors` and `create_beagle` processes have been split off to a new subworkflow `PROB_GENOTYPING` (currently disabled). This is an experimental workflow that is designed to generate genotype likelihood and posterior probability outputs for those wishing to conduct probablistic analysis with `ANGSD`. But this needs some further testing on real data to ensure it works as desired. Ill work on this in a future PR.

