### PR TITLE
Population labels and visualisation

### DIFF
--- a/bin/create_beagle.sh
+++ b/bin/create_beagle.sh
@@ -25,7 +25,7 @@ if [[ "${4}" == "true" ]]; then
         -x FORMAT/PL \
         --rename-annots rename_file \
         -o tmp.vcf
-    outname='${prefix}.pp'
+    outname=${prefix}.pp
 else
     # keep only sites where *at least one* sample has a PL value
     # TODO: Investigate why a few samples are missing PL values, are these the invariants with multiple alleles in VCF?
@@ -33,7 +33,7 @@ else
         -i 'COUNT(FMT/PL!=".") > 0' \
         -o tmp.vcf \
         ${2}
-    outname='${prefix}.gl'
+    outname=${prefix}.gl
 fi
 
 # Use BCFtools to convert phred scaled likelihoods into probabilities (similar to beagle file)

--- a/bin/create_beagle.sh
+++ b/bin/create_beagle.sh
@@ -7,6 +7,9 @@ set -u
 # $3 = ref_genome
 # $4 = posterior
 
+# Get prefix of vcf file for output name
+prefix=$(echo ${2} | cut -d'.' -f1)
+
 # Note - beagle output only works for polymorphic sites but indels and nonvariants are supported
 
 if [[ "${4}" == "true" ]]; then
@@ -22,7 +25,7 @@ if [[ "${4}" == "true" ]]; then
         -x FORMAT/PL \
         --rename-annots rename_file \
         -o tmp.vcf
-    outname='pp'
+    outname='${prefix}.pp'
 else
     # keep only sites where *at least one* sample has a PL value
     # TODO: Investigate why a few samples are missing PL values, are these the invariants with multiple alleles in VCF?
@@ -30,7 +33,7 @@ else
         -i 'COUNT(FMT/PL!=".") > 0' \
         -o tmp.vcf \
         ${2}
-    outname='gl'
+    outname='${prefix}.gl'
 fi
 
 # Use BCFtools to convert phred scaled likelihoods into probabilities (similar to beagle file)

--- a/bin/create_pseudohap.sh
+++ b/bin/create_pseudohap.sh
@@ -74,23 +74,23 @@ bcftools index -t ${prefix}_pseudohaploid.vcf.gz
 # Output genotype matrix (angsd style)
 
 # Create header
-{
-  printf "chr\tpos\tmajor\tminor";
-  bcftools query -l ${prefix}_pseudohaploid.vcf.gz | while read s; do printf '\t%s' "$s"; done
-  printf '\n'
-} > ${prefix}_pseudohaploid.tsv
-
-bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%PH]\n' ${prefix}_pseudohaploid.vcf.gz \
-    | awk -F'\t' 'BEGIN{OFS="\t"}
-    {
-    chr=$1; pos=$2; ref=$3; alt=$4;
-    printf "%s\t%s\t%s\t%s", chr, pos, ref, alt
-
-    for (i=5; i<=NF; i++) {
-        if ($i=="0")      out=0;       # REF
-        else if ($i=="1") out=1;       # ALT
-        else              out=-1;      # missing or unexpected
-        printf "\t%s", out
-    }
-    printf "\n"
-    }' >> ${prefix}_pseudohaploid.tsv
+#{
+#  printf "chr\tpos\tmajor\tminor";
+#  bcftools query -l ${prefix}_pseudohaploid.vcf.gz | while read s; do printf '\t%s' "$s"; done
+#  printf '\n'
+#} > ${prefix}_pseudohaploid.tsv
+#
+#bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%PH]\n' ${prefix}_pseudohaploid.vcf.gz \
+#    | awk -F'\t' 'BEGIN{OFS="\t"}
+#    {
+#    chr=$1; pos=$2; ref=$3; alt=$4;
+#    printf "%s\t%s\t%s\t%s", chr, pos, ref, alt
+#
+#    for (i=5; i<=NF; i++) {
+#        if ($i=="0")      out=0;       # REF
+#        else if ($i=="1") out=1;       # ALT
+#        else              out=-1;      # missing or unexpected
+#        printf "\t%s", out
+#    }
+#    printf "\n"
+#    }' >> ${prefix}_pseudohaploid.tsv

--- a/bin/create_pseudohap.sh
+++ b/bin/create_pseudohap.sh
@@ -6,6 +6,9 @@ set -u
 # $2 = vcf
 # $3 = ref_genome
 
+# Get prefix of vcf file for output name
+prefix=$(echo ${2} | cut -d'.' -f1)
+
 # Note - beagle output only works for polymorphic sites but indels and nonvariants are supported
 
 # sample list
@@ -64,20 +67,20 @@ bcftools index -t raw.withPH.vcf.gz
 # 3 set ./., where PH is missing
 bcftools +setGT raw.withPH.vcf.gz -Ou -- -t q -n c:0/0 -i 'FMT/PH=="0"' \
     | bcftools +setGT -Ou -- -t q -n c:1/1 -i 'FMT/PH=="1"' \
-    | bcftools +setGT -Oz -o pseudohaploid.vcf.gz -- -t q -n . -i 'FMT/PH=="."' 
+    | bcftools +setGT -Oz -o ${prefix}_pseudohaploid.vcf.gz -- -t q -n . -i 'FMT/PH=="."' 
 
-bcftools index -t pseudohaploid.vcf.gz
+bcftools index -t ${prefix}_pseudohaploid.vcf.gz
 
 # Output genotype matrix (angsd style)
 
 # Create header
 {
   printf "chr\tpos\tmajor\tminor";
-  bcftools query -l pseudohaploid.vcf.gz | while read s; do printf '\t%s' "$s"; done
+  bcftools query -l ${prefix}_pseudohaploid.vcf.gz | while read s; do printf '\t%s' "$s"; done
   printf '\n'
-} > pseudohaploid.tsv
+} > ${prefix}_pseudohaploid.tsv
 
-bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%PH]\n' pseudohaploid.vcf.gz \
+bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%PH]\n' ${prefix}_pseudohaploid.vcf.gz \
     | awk -F'\t' 'BEGIN{OFS="\t"}
     {
     chr=$1; pos=$2; ref=$3; alt=$4;
@@ -90,4 +93,4 @@ bcftools query -f '%CHROM\t%POS\t%REF\t%ALT[\t%PH]\n' pseudohaploid.vcf.gz \
         printf "\t%s", out
     }
     printf "\n"
-    }' >> pseudohaploid.tsv
+    }' >> ${prefix}_pseudohaploid.tsv

--- a/bin/plot_ordination.R
+++ b/bin/plot_ordination.R
@@ -78,6 +78,11 @@ tryCatch(
 
       # Extract data for ordination
       pcx <- as.data.frame(mds$Ybar)
+
+      # Handle missing second dimenson if there was not enough data to generate
+      if (ncol(pcx) == 1) {
+        pcx$Dim2 <- 0
+      }
       colnames(pcx) <- paste0("PC", seq(1, ncol(pcx), 1))
 
       # Plot ordination

--- a/bin/plot_ordination.R
+++ b/bin/plot_ordination.R
@@ -46,16 +46,7 @@ tryCatch(
     )
 
     # Mat is square (samples x samples)
-    drop <- apply(
-      M,
-      1,
-      function(r, i) {
-        # remove the self-comparison (diagonal) before testing
-        all(is.na(r[-i]) | is.nan(r[-i]))
-      },
-      i = seq_len(nrow(M))
-    )
-
+    drop <- rowSums(!is.na(M)) == 1
     M_clean <- M[!drop, !drop, drop = FALSE]
 
     # Check if matrix still has dimensions

--- a/bin/plot_ordination.R
+++ b/bin/plot_ordination.R
@@ -59,7 +59,7 @@ tryCatch(
     M_clean <- M[!drop, !drop, drop = FALSE]
 
     # Check if matrix still has dimensions
-    if (!is.null(dim(M_clean)) || !any(dim(M_clean) == 0)) {
+    if (!any(dim(M_clean) == 0)) {
       # Convert matrix to dist matrix
       distmat <- as.dist(M_clean)
 

--- a/bin/plot_ordination.R
+++ b/bin/plot_ordination.R
@@ -35,8 +35,8 @@ tryCatch(
     prefix <- mat_file %>% stringr::str_remove("\\..*$")
 
     # Read in matrix files
-    mat <- read.table(mat_file, row.names = 1)
-    colnames(mat) <- rownames(mat)
+    M <- read.table(mat_file, row.names = 1)
+    colnames(M) <- rownames(M)
 
     # Read in popmap file
     popmap <- read.table(
@@ -45,47 +45,75 @@ tryCatch(
       col.names = c("sample", "pop")
     )
 
-    # Convert matrix to dist matrix
-    distmat <- as.dist(mat)
-
-    # TODO: Check if the input is a convariance matrix, if so run eigen function
-
-    # Conduct MDS
-    mds <- capscale(distmat ~ 1)
-
-    # Get target principal components to plot
-    target_pc <- c("PC1", "PC2")
-
-    # Create variance explained labels
-    var_exp <- scales::percent(mds$CA$eig / sum(mds$CA$eig), accuracy = 0.1)
-    names(var_exp) <- names(var_exp) %>% str_replace("MDS", "PC")
-    lab_x <- paste0(
-      target_pc[1],
-      " (",
-      var_exp[match(target_pc[1], names(var_exp))],
-      ")"
-    )
-    lab_y <- paste0(
-      target_pc[2],
-      " (",
-      var_exp[match(target_pc[2], names(var_exp))],
-      ")"
+    # Mat is square (samples x samples)
+    drop <- apply(
+      M,
+      1,
+      function(r, i) {
+        # remove the self-comparison (diagonal) before testing
+        all(is.na(r[-i]) | is.nan(r[-i]))
+      },
+      i = seq_len(nrow(M))
     )
 
-    # Extract data for ordination
-    pcx <- as.data.frame(mds$Ybar)
-    colnames(pcx) <- paste0("PC", seq(1, ncol(pcx), 1))
+    M_clean <- M[!drop, !drop, drop = FALSE]
 
-    # Plot ordination
-    gg.ord <- pcx %>%
-      dplyr::select(paste0("PC", seq(1, 2, 1))) %>% #select top 2 PCs
-      tibble::rownames_to_column("sample") %>%
-      dplyr::left_join(popmap) %>%
-      ggplot(aes(-get(target_pc[1]), get(target_pc[2]), colour = pop)) +
-      geom_point(size = 2) +
-      labs(x = lab_x, y = lab_y) +
-      theme_classic() +
-      theme(legend.position = "right")
+    # Check if matrix still has dimensions
+    if (!is.null(dim(M_clean)) || !any(dim(M_clean) == 0)) {
+      # Convert matrix to dist matrix
+      distmat <- as.dist(M_clean)
+
+      # Conduct MDS
+      mds <- capscale(distmat ~ 1)
+
+      # Get target principal components to plot
+      target_pc <- c("PC1", "PC2")
+
+      # Create variance explained labels
+      var_exp <- scales::percent(mds$CA$eig / sum(mds$CA$eig), accuracy = 0.1)
+      names(var_exp) <- names(var_exp) %>% str_replace("MDS", "PC")
+      lab_x <- paste0(
+        target_pc[1],
+        " (",
+        var_exp[match(target_pc[1], names(var_exp))],
+        ")"
+      )
+      lab_y <- paste0(
+        target_pc[2],
+        " (",
+        var_exp[match(target_pc[2], names(var_exp))],
+        ")"
+      )
+
+      # Extract data for ordination
+      pcx <- as.data.frame(mds$Ybar)
+      colnames(pcx) <- paste0("PC", seq(1, ncol(pcx), 1))
+
+      # Plot ordination
+      gg.ord <- pcx %>%
+        dplyr::select(paste0("PC", seq(1, 2, 1))) %>% #select top 2 PCs
+        tibble::rownames_to_column("sample") %>%
+        dplyr::left_join(popmap) %>%
+        ggplot(aes(-get(target_pc[1]), get(target_pc[2]), colour = pop)) +
+        geom_point(size = 2) +
+        labs(x = lab_x, y = lab_y) +
+        theme_classic() +
+        theme(legend.position = "right")
+    } else {
+      # If all are dropped by NAN filter, create empty plot
+      gg.ord <- ggplot() +
+        xlim(0, 1) +
+        ylim(0, 1) + # give coords to place the text
+        annotate(
+          "text",
+          x = .5,
+          y = .5,
+          label = "All comparisons are NAN",
+          size = 6,
+          fontface = "bold"
+        ) +
+        theme_void()
+    }
 
     # Write out plots
     pdf(paste0(prefix, "_ord.pdf"), width = 11, height = 8)

--- a/bin/plot_ordination.R
+++ b/bin/plot_ordination.R
@@ -1,0 +1,96 @@
+#!/usr/bin/env Rscript
+
+tryCatch(
+  {
+    args <- commandArgs(trailingOnly = TRUE)
+
+    projectDir <- args[1]
+    params.rdata <- args[2]
+    params.covariance <- args[3]
+    #popmap <- args[3]
+
+    # TESTING
+    #params.snp_qd <- 2.0
+
+    sys.source(paste0(projectDir, "/bin/functions.R"), envir = .GlobalEnv)
+
+    ### load only required packages
+    process_packages <- c(
+      "dplyr",
+      "tidyr",
+      "readr",
+      "ggplot2",
+      "stringr",
+      "vegan",
+      NULL
+    )
+    invisible(lapply(
+      process_packages,
+      library,
+      character.only = TRUE,
+      warn.conflicts = FALSE
+    ))
+
+    ### run code
+
+    # List matrix files
+    mat_files <- list.files(pattern = "\\.mat$")
+
+    prefix <- mat_files %>% stringr::str_remove("\\..*$")
+
+    # Read in matrix files
+    mat <- read.table(mat_files, row.names = 1)
+    colnames(mat) <- rownames(mat)
+
+    # TODO: Check if the input is a convariance matrix, if so run eigen function
+
+    # TODO: Handle population labels - if missing colour by sample
+
+    # Conduct MDS
+    mds <- capscale(mat ~ 1)
+
+    # Get target principal components to plot
+    target_pc <- c("PC1", "PC2")
+
+    # Create variance explained labels
+    var_exp <- scales::percent(mds$CA$eig / sum(mds$CA$eig), accuracy = 0.1)
+    names(var_exp) <- names(var_exp) %>% str_replace("MDS", "PC")
+    lab_x <- paste0(
+      target_pc[1],
+      " (",
+      var_exp[match(target_pc[1], names(var_exp))],
+      ")"
+    )
+    lab_y <- paste0(
+      target_pc[2],
+      " (",
+      var_exp[match(target_pc[2], names(var_exp))],
+      ")"
+    )
+
+    # Extract data for ordination
+    pcx <- as.data.frame(mds$Ybar)
+    colnames(pcx) <- paste0("PC", seq(1, ncol(pcx), 1))
+
+    # Plot ordination
+    gg.ord <- pcx %>%
+      dplyr::select(paste0("PC", seq(1, 2, 1))) %>%
+      tibble::rownames_to_column("sample") %>%
+      ggplot(aes(-get(target_pc[1]), get(target_pc[2]))) + #, colour = pop
+      geom_point(size = 2) +
+      labs(x = lab_x, y = lab_y) +
+      theme_classic() +
+      theme(legend.position = "none")
+
+    # Write out plots
+    pdf(paste0(prefix, "_ord.pdf"), width = 11, height = 8)
+    plot(gg.ord)
+    try(dev.off(), silent = TRUE)
+  },
+  finally = {
+    ### save R environment if script throws error code
+    if (params.rdata == "true") {
+      save.image(file = "CREATE_INTERVALS.rda")
+    }
+  }
+)

--- a/bin/plot_ordination.R
+++ b/bin/plot_ordination.R
@@ -9,9 +9,6 @@ tryCatch(
     params.covariance <- args[3]
     #popmap <- args[3]
 
-    # TESTING
-    #params.snp_qd <- 2.0
-
     sys.source(paste0(projectDir, "/bin/functions.R"), envir = .GlobalEnv)
 
     ### load only required packages
@@ -42,12 +39,15 @@ tryCatch(
     mat <- read.table(mat_files, row.names = 1)
     colnames(mat) <- rownames(mat)
 
+    # Convert to distance matrix
+    distmat <- as.dist(mat)
+
     # TODO: Check if the input is a convariance matrix, if so run eigen function
 
     # TODO: Handle population labels - if missing colour by sample
 
     # Conduct MDS
-    mds <- capscale(mat ~ 1)
+    mds <- capscale(distmat ~ 1)
 
     # Get target principal components to plot
     target_pc <- c("PC1", "PC2")

--- a/bin/plot_ordination.R
+++ b/bin/plot_ordination.R
@@ -90,7 +90,7 @@ tryCatch(
   finally = {
     ### save R environment if script throws error code
     if (params.rdata == "true") {
-      save.image(file = "CREATE_INTERVALS.rda")
+      save.image(file = "PLOT_ORDINATION.rda")
     }
   }
 )

--- a/bin/plot_tree.R
+++ b/bin/plot_tree.R
@@ -39,7 +39,7 @@ tryCatch(
     distmat <- as.dist(mat)
 
     # Construct a tree using NJ method
-    tree <- nj(distmat)
+    tree <- ape::nj(distmat)
 
     # save the tree to Newick format file
     write.tree(tree, file = paste0(prefix, "_tree.nwk"))

--- a/bin/plot_tree.R
+++ b/bin/plot_tree.R
@@ -46,15 +46,8 @@ tryCatch(
     )
 
     # Mat is square (samples x samples)
-    drop <- apply(
-      M,
-      1,
-      function(r, i) {
-        # remove the self-comparison (diagonal) before testing
-        all(is.na(r[-i]) | is.nan(r[-i]))
-      },
-      i = seq_len(nrow(M))
-    )
+    drop <- rowSums(!is.na(M)) == 1
+    M_clean <- M[!drop, !drop, drop = FALSE]
 
     M_clean <- M[!drop, !drop, drop = FALSE]
 

--- a/bin/plot_tree.R
+++ b/bin/plot_tree.R
@@ -6,8 +6,7 @@ tryCatch(
 
     projectDir <- args[1]
     params.rdata <- args[2]
-    params.covariance <- args[3]
-    #popmap <- args[3]
+    popmap <- args[3]
 
     sys.source(paste0(projectDir, "/bin/functions.R"), envir = .GlobalEnv)
 

--- a/bin/plot_tree.R
+++ b/bin/plot_tree.R
@@ -59,7 +59,7 @@ tryCatch(
   finally = {
     ### save R environment if script throws error code
     if (params.rdata == "true") {
-      save.image(file = "CREATE_INTERVALS.rda")
+      save.image(file = "PLOT_TREE.rda")
     }
   }
 )

--- a/bin/plot_tree.R
+++ b/bin/plot_tree.R
@@ -1,0 +1,65 @@
+#!/usr/bin/env Rscript
+
+tryCatch(
+  {
+    args <- commandArgs(trailingOnly = TRUE)
+
+    projectDir <- args[1]
+    params.rdata <- args[2]
+    params.covariance <- args[3]
+    #popmap <- args[3]
+
+    sys.source(paste0(projectDir, "/bin/functions.R"), envir = .GlobalEnv)
+
+    ### load only required packages
+    process_packages <- c(
+      "dplyr",
+      "tidyr",
+      "readr",
+      "ggplot2",
+      "stringr",
+      "ape",
+      "ggtree",
+      NULL
+    )
+    invisible(lapply(
+      process_packages,
+      library,
+      character.only = TRUE,
+      warn.conflicts = FALSE
+    ))
+
+    ### run code
+
+    # List matrix files
+    mat_files <- list.files(pattern = "\\.mat$")
+
+    prefix <- mat_files %>% stringr::str_remove("\\..*$")
+
+    # Read in matrix files
+    mat <- read.table(mat_files, row.names = 1)
+    colnames(mat) <- rownames(mat)
+
+    # Convert to dist matrix
+    distmat <- as.dist(mat)
+
+    # Construct a tree using NJ method
+    tree <- nj(distmat)
+
+    # save the tree to Newick format file
+    write.tree(tree, file = paste0(prefix, "_tree.nwk"))
+
+    gg.tree <- ggtree(tree, layout = "equal_angle") # see more at ggtree
+
+    # Write out plots
+    pdf(paste0(prefix, "_tree.pdf"), width = 11, height = 8)
+    plot(gg.tree)
+    try(dev.off(), silent = TRUE)
+  },
+  finally = {
+    ### save R environment if script throws error code
+    if (params.rdata == "true") {
+      save.image(file = "CREATE_INTERVALS.rda")
+    }
+  }
+)

--- a/bin/plot_tree.R
+++ b/bin/plot_tree.R
@@ -58,7 +58,7 @@ tryCatch(
     M_clean <- M[!drop, !drop, drop = FALSE]
 
     # Check if matrix still has dimensions
-    if (!is.null(dim(M_clean)) || !any(dim(M_clean) == 0)) {
+    if (!any(dim(M_clean) == 0)) {
       # Convert matrix to dist matrix
       distmat <- as.dist(M_clean)
 

--- a/bin/plot_tree.R
+++ b/bin/plot_tree.R
@@ -13,11 +13,6 @@ tryCatch(
 
     ### load only required packages
     process_packages <- c(
-      "dplyr",
-      "tidyr",
-      "readr",
-      "ggplot2",
-      "stringr",
       "ape",
       "ggtree",
       NULL

--- a/bin/plot_tree.R
+++ b/bin/plot_tree.R
@@ -19,6 +19,7 @@ tryCatch(
       "dplyr",
       "ape",
       "ggtree",
+      "ggplot2",
       NULL
     )
     invisible(lapply(
@@ -79,10 +80,11 @@ tryCatch(
       ) %>%
         dplyr::left_join(popmap)
 
+      # Update tree with labels
       gg.tree <- p1 %<+% (tree_df) + aes(color = pop) + geom_tiplab()
     } else {
       # If all are dropped by NAN filter, create empty plot
-      gg.ord <- ggplot() +
+      gg.tree <- ggplot() +
         xlim(0, 1) +
         ylim(0, 1) + # give coords to place the text
         annotate(

--- a/bin/plot_variant_qc.R
+++ b/bin/plot_variant_qc.R
@@ -177,7 +177,7 @@ tryCatch(
   finally = {
     ### save R environment if script throws error code
     if (params.rdata == "true") {
-      save.image(file = "CREATE_INTERVALS.rda")
+      save.image(file = "PLOT_VARIANT_QC.rda")
     }
   }
 )

--- a/bin/vcf2dist.sh
+++ b/bin/vcf2dist.sh
@@ -4,15 +4,25 @@ set -u
 ## args are the following:
 # $1 = cpus 
 # $2 = vcf
-# $3 = ref_genome
 
-
-# Get basename of vcf file for outpt
+# Get prefix of vcf file for output name
+prefix=$(echo ${2} | cut -d'.' -f1)
 
 # Rename samples to an ID to fit into VCF2Dis character limits
+bcftools query -l ${2} | awk '{printf "%s\tS%d\n",$0,NR}'> sample.map
+cat sample.map | cut -f2 > newnames.txt
+bcftools reheader -s newnames.txt -o tmp.vcf.gz ${2}
 
 # Run VCF2DIS
-VCF2Dis	-InPut	${2}.vcf.gz -OutPut p_dis.mat
+VCF2Dis	-InPut tmp.vcf.gz -OutPut tmp.mat
 
-# Re-add sample names
+# Re-add sample names to output file
+awk '{print $2"\t"$1}' sample.map > map.back.tsv
 
+awk 'NR==FNR{m[$1]=$2; next}          # read map into m[]
+     NR==1{print; next}               # keep header if there is one
+     {$1 = (m[$1]?m[$1]:$1); print}'  \
+    OFS='\t' map.back.tsv tmp.mat > ${prefix}.mat
+
+# Remove temporary files
+rm tmp.vcf.gz* 

--- a/bin/vcf2dist.sh
+++ b/bin/vcf2dist.sh
@@ -22,7 +22,7 @@ awk '{print $2"\t"$1}' sample.map > map.back.tsv
 awk 'NR==FNR{m[$1]=$2; next}          # read map into m[]
      NR==1{print; next}               # keep header if there is one
      {$1 = (m[$1]?m[$1]:$1); print}'  \
-    OFS='\t' map.back.tsv tmp.mat > ${prefix}.mat
+    OFS='\t' map.back.tsv tmp.mat | tail -n +2 > ${prefix}.mat
 
 # Remove temporary files
-rm tmp.vcf.gz* 
+rm tmp.vcf.gz* tmp.mat

--- a/bin/vcf2dist.sh
+++ b/bin/vcf2dist.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+set -u
+## args are the following:
+# $1 = cpus 
+# $2 = vcf
+# $3 = ref_genome
+
+
+# Get basename of vcf file for outpt
+
+# Rename samples to an ID to fit into VCF2Dis character limits
+
+# Run VCF2DIS
+VCF2Dis	-InPut	${2}.vcf.gz -OutPut p_dis.mat
+
+# Re-add sample names
+

--- a/dev_notes/dev_notes.md
+++ b/dev_notes/dev_notes.md
@@ -98,6 +98,9 @@ export NXF_VER=23.05.0-edge
 
 module load Java/17
 
+# Make sure permissions are fixed for R scripts
+chmod +777 bin/*.R
+
 # Test
 nextflow run . -profile basc_modules,debug,test
 ```

--- a/dev_notes/dev_notes.md
+++ b/dev_notes/dev_notes.md
@@ -83,9 +83,12 @@ fwd=$( find test_data/qfly/ -maxdepth 1 -name '*.fastq.gz' -type f | grep '_R1' 
 rev=$(echo "$fwd" | sed 's/_R1/_R2/g' )
 sample_id=$(echo "$fwd" | sed 's/_subset.*$//g' | sed 's/^.*\///g')
 
+# Create fake population labels
+pop=$(echo -e "Pop1\nPop1\nPop2\nPop3")
+
 # format sample,fastq_1,fastq_2,
-paste -d ',' <(echo "sample_id") <(echo "fwd") <(echo "rev") > test_data/qfly/test_samplesheet.csv
-paste -d ',' <(echo "$sample_id") <(echo "$fwd") <(echo "$rev") >> test_data/qfly/test_samplesheet.csv
+paste -d ',' <(echo "sample_id") <(echo "pop") <(echo "fwd") <(echo "rev") > test_data/qfly/test_samplesheet.csv
+paste -d ',' <(echo "$sample_id") <(echo "$pop")  <(echo "$fwd") <(echo "$rev") >> test_data/qfly/test_samplesheet.csv
 ```
 
 ### Run test datasets
@@ -102,5 +105,5 @@ module load Java/17
 chmod +777 bin/*.R
 
 # Test
-nextflow run . -profile basc_modules,debug,test
+nextflow run . -profile basc_modules,debug,test -resume
 ```

--- a/nextflow.config
+++ b/nextflow.config
@@ -386,13 +386,18 @@ process {
         time    = { time_scale ( 1.h,   task.attempt ) }
     }   
 
-    //Low coverage outputs (currently disabled)
+    //Outputs subworkflow
     withName: CREATE_BEAGLE {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 24.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }
     }
     withName: CREATE_PSEUDOHAP {
+        cpus    = { cpu_scale  ( 1,     task.attempt ) }
+        memory  = { mem_scale  ( 24.GB,  task.attempt ) }
+        time    = { time_scale ( 30.m,   task.attempt ) }
+    }
+    withName: VCF2DIST {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 24.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }

--- a/nextflow.config
+++ b/nextflow.config
@@ -407,7 +407,11 @@ process {
         memory  = { mem_scale  ( 2.GB,  task.attempt ) }
         time    = { time_scale ( 5.m,   task.attempt ) }
     }
-
+    withName: PLOT_TREE {
+        cpus    = { cpu_scale  ( 1,     task.attempt ) }
+        memory  = { mem_scale  ( 2.GB,  task.attempt ) }
+        time    = { time_scale ( 5.m,   task.attempt ) }
+    }
     //Depreciated process resources
     //withName: GENOTYPE_POSTERIORS {
     //    cpus    = { cpu_scale  ( 2,     task.attempt ) }

--- a/nextflow.config
+++ b/nextflow.config
@@ -402,6 +402,11 @@ process {
         memory  = { mem_scale  ( 24.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }
     }
+    withName: PLOT_ORDINATION {
+        cpus    = { cpu_scale  ( 1,     task.attempt ) }
+        memory  = { mem_scale  ( 2.GB,  task.attempt ) }
+        time    = { time_scale ( 5.m,   task.attempt ) }
+    }
 
     //Depreciated process resources
     //withName: GENOTYPE_POSTERIORS {

--- a/nextflow/modules/bam_stats.nf
+++ b/nextflow/modules/bam_stats.nf
@@ -1,7 +1,7 @@
 process BAM_STATS {
     def process_name = "bam_stats"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/call_variants.nf
+++ b/nextflow/modules/call_variants.nf
@@ -1,7 +1,7 @@
 process CALL_VARIANTS {
     def process_name = "call_variants"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 

--- a/nextflow/modules/combine_gvcfs.nf
+++ b/nextflow/modules/combine_gvcfs.nf
@@ -1,7 +1,7 @@
 process COMBINE_GVCFS {
     def process_name = "combine_gvcfs"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 

--- a/nextflow/modules/consensus_mito.nf
+++ b/nextflow/modules/consensus_mito.nf
@@ -1,7 +1,7 @@
 process CONSENSUS_MITO {
     def process_name = "consensus_mito"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BCFtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/consensus_mito.nf
+++ b/nextflow/modules/consensus_mito.nf
@@ -2,6 +2,8 @@ process CONSENSUS_MITO {
     def process_name = "consensus_mito"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/mito", mode: 'copy'
+
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BCFtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/convert_intervals.nf
+++ b/nextflow/modules/convert_intervals.nf
@@ -1,7 +1,7 @@
 process CONVERT_INTERVALS {
     def process_name = "convert_intervals"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 

--- a/nextflow/modules/count_reads_bins.nf
+++ b/nextflow/modules/count_reads_bins.nf
@@ -1,7 +1,7 @@
 process COUNT_READS_BINS {
     def process_name = "count_reads_bins"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 

--- a/nextflow/modules/create_beagle.nf
+++ b/nextflow/modules/create_beagle.nf
@@ -1,7 +1,7 @@
 process CREATE_BEAGLE {
     def process_name = "create_beagle"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BCFtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/create_beagle.nf
+++ b/nextflow/modules/create_beagle.nf
@@ -2,6 +2,7 @@ process CREATE_BEAGLE {
     def process_name = "create_beagle"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/beagle", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BCFtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/create_bed_intervals.nf
+++ b/nextflow/modules/create_bed_intervals.nf
@@ -1,7 +1,7 @@
 process CREATE_BED_INTERVALS {
     def process_name = "create_bed_intervals"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BEDTools/2.31.1-GCC-13.3.0:GATK/4.6.1.0-GCCcore-13.3.0-Java-21:picard/3.3.0-Java-21"
 

--- a/nextflow/modules/create_genome_bins.nf
+++ b/nextflow/modules/create_genome_bins.nf
@@ -1,7 +1,7 @@
 process CREATE_GENOME_BINS {
     def process_name = "create_genome_bins"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:picard/3.3.0-Java-21"
 

--- a/nextflow/modules/create_genome_masks.nf
+++ b/nextflow/modules/create_genome_masks.nf
@@ -1,7 +1,7 @@
 process CREATE_GENOME_MASKS {
     def process_name = "create_genome_masks"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BEDTools/2.31.1-GCC-13.3.0:GATK/4.6.1.0-GCCcore-13.3.0-Java-21:picard/3.3.0-Java-21:SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/create_intervals.nf
+++ b/nextflow/modules/create_intervals.nf
@@ -1,7 +1,7 @@
 process CREATE_INTERVALS {
     def process_name = "create_intervals"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "shifter/22.02.1"
 

--- a/nextflow/modules/create_masks_bins.nf
+++ b/nextflow/modules/create_masks_bins.nf
@@ -1,7 +1,7 @@
 process CREATE_MASKS_BINS {
     def process_name = "create_masks_bins"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BEDTools/2.31.1-GCC-13.3.0:GATK/4.6.1.0-GCCcore-13.3.0-Java-21:picard/3.3.0-Java-21"
 

--- a/nextflow/modules/create_pseudohap.nf
+++ b/nextflow/modules/create_pseudohap.nf
@@ -2,6 +2,7 @@ process CREATE_PSEUDOHAP {
     def process_name = "create_pseudohap"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/vcf/pseudohaploid", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BCFtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/create_pseudohap.nf
+++ b/nextflow/modules/create_pseudohap.nf
@@ -1,7 +1,7 @@
 process CREATE_PSEUDOHAP {
     def process_name = "create_pseudohap"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BCFtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/create_pseudohap.nf
+++ b/nextflow/modules/create_pseudohap.nf
@@ -11,7 +11,7 @@ process CREATE_PSEUDOHAP {
 
     output: 
     tuple path("*pseudohaploid.vcf.gz"), path("*pseudohaploid.vcf.gz.tbi"),   emit: vcf
-    path("*pseudohaploid.tsv"),                                               emit: tsv
+    //path("*pseudohaploid.tsv"),                                               emit: tsv
 
     script:
     def process_script = "${process_name}.sh"

--- a/nextflow/modules/create_pseudohap.nf
+++ b/nextflow/modules/create_pseudohap.nf
@@ -10,8 +10,8 @@ process CREATE_PSEUDOHAP {
     tuple path(ref_genome), path(genome_index_files)
 
     output: 
-    path("*pseudohaploid.vcf.gz"),                           emit: vcf
-    path("*pseudohaploid.tsv"),                              emit: tsv
+    tuple path("*pseudohaploid.vcf.gz"), path("*pseudohaploid.vcf.gz.tbi"),   emit: vcf
+    path("*pseudohaploid.tsv"),                                               emit: tsv
 
     script:
     def process_script = "${process_name}.sh"

--- a/nextflow/modules/extract_unmapped.nf
+++ b/nextflow/modules/extract_unmapped.nf
@@ -2,6 +2,7 @@ process EXTRACT_UNMAPPED {
     def process_name = "extract_unmapped"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/unmapped", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/extract_unmapped.nf
+++ b/nextflow/modules/extract_unmapped.nf
@@ -1,7 +1,7 @@
 process EXTRACT_UNMAPPED {
     def process_name = "extract_unmapped"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/fastp.nf
+++ b/nextflow/modules/fastp.nf
@@ -1,7 +1,7 @@
 process FASTP {
     def process_name = "fastp"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "fastp/0.23.4-GCC-13.3.0"
 

--- a/nextflow/modules/fastqc.nf
+++ b/nextflow/modules/fastqc.nf
@@ -1,7 +1,7 @@
 process FASTQC {
     def process_name = "fastqc"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "FastQC/0.12.1-Java-11"
 

--- a/nextflow/modules/fastqtobam.nf
+++ b/nextflow/modules/fastqtobam.nf
@@ -1,7 +1,7 @@
 process FASTQTOBAM {
     def process_name = "fastqtobam"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "fastp/0.23.4-GCC-13.3.0:bwa-mem2/2.2.1-GCC-13.3.0:SAMtools/1.21-GCC-13.3.0:SeqKit/2.8.2"
 

--- a/nextflow/modules/filter_indels.nf
+++ b/nextflow/modules/filter_indels.nf
@@ -1,7 +1,7 @@
 process FILTER_INDELS {
     def process_name = "filter_indels"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/filter_indels.nf
+++ b/nextflow/modules/filter_indels.nf
@@ -2,7 +2,7 @@ process FILTER_INDELS {
     def process_name = "filter_indels"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
-    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy'
+    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy', pattern: "*vcf.gz*"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/filter_indels.nf
+++ b/nextflow/modules/filter_indels.nf
@@ -2,6 +2,7 @@ process FILTER_INDELS {
     def process_name = "filter_indels"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/filter_invariant.nf
+++ b/nextflow/modules/filter_invariant.nf
@@ -1,7 +1,7 @@
 process FILTER_INVARIANT {
     def process_name = "filter_invariant"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/filter_invariant.nf
+++ b/nextflow/modules/filter_invariant.nf
@@ -2,6 +2,7 @@ process FILTER_INVARIANT {
     def process_name = "filter_invariant"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/filter_invariant.nf
+++ b/nextflow/modules/filter_invariant.nf
@@ -2,7 +2,7 @@ process FILTER_INVARIANT {
     def process_name = "filter_invariant"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
-    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy'
+    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy', pattern: "*vcf.gz*"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/filter_snps.nf
+++ b/nextflow/modules/filter_snps.nf
@@ -2,7 +2,7 @@ process FILTER_SNPS {
     def process_name = "filter_snps"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
-    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy'
+    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy', pattern: "*vcf.gz*"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/filter_snps.nf
+++ b/nextflow/modules/filter_snps.nf
@@ -2,6 +2,7 @@ process FILTER_SNPS {
     def process_name = "filter_snps"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/filter_snps.nf
+++ b/nextflow/modules/filter_snps.nf
@@ -1,7 +1,7 @@
 process FILTER_SNPS {
     def process_name = "filter_snps"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:pigz/2.8-GCCcore-13.3.0:BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/genomicsdb_import.nf
+++ b/nextflow/modules/genomicsdb_import.nf
@@ -1,7 +1,7 @@
 process GENOMICSDB_IMPORT {
     def process_name = "genomicsdb_import"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 

--- a/nextflow/modules/genotype_posteriors.nf
+++ b/nextflow/modules/genotype_posteriors.nf
@@ -1,7 +1,7 @@
 process GENOTYPE_POSTERIORS {
     def process_name = "genotype_posteriors"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 

--- a/nextflow/modules/index_genome.nf
+++ b/nextflow/modules/index_genome.nf
@@ -1,7 +1,7 @@
 process INDEX_GENOME {
     def process_name = "index_genome"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "bwa-mem2/2.2.1-GCC-13.3.0:BEDTools/2.31.1-GCC-13.3.0:GATK/4.6.1.0-GCCcore-13.3.0-Java-21:picard/3.3.0-Java-21:SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/index_mito.nf
+++ b/nextflow/modules/index_mito.nf
@@ -1,7 +1,7 @@
 process INDEX_MITO {
     def process_name = "index_mito"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "bwa-mem2/2.2.1-GCC-13.3.0:SAMtools/1.21-GCC-13.3.0:seqtk/1.4-GCC-13.3.0"
 

--- a/nextflow/modules/joint_genotype.nf
+++ b/nextflow/modules/joint_genotype.nf
@@ -1,6 +1,6 @@
 process JOINT_GENOTYPE {
     def process_name = "joint_genotype"    
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:BCFtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/map_to_genome.nf
+++ b/nextflow/modules/map_to_genome.nf
@@ -1,11 +1,7 @@
 process MAP_TO_GENOME {
     def process_name = "map_to_genome"    
     // tag "-"
-    // label "small"
-    time '1.h'
-    memory '8.GB'
-    cpus 4
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "bwa-mem2/2.2.1-GCC-13.3.0:SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/map_to_mito.nf
+++ b/nextflow/modules/map_to_mito.nf
@@ -1,11 +1,7 @@
 process MAP_TO_MITO {
     def process_name = "map_to_mito"    
     // tag "-"
-    // label "small"
-    time '1.h'
-    memory '8.GB'
-    cpus 4
-    // publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "bwa-mem2/2.2.1-GCC-13.3.0:SAMtools/1.21-GCC-13.3.0:SeqKit/2.8.2"
 

--- a/nextflow/modules/merge_filter_bam.nf
+++ b/nextflow/modules/merge_filter_bam.nf
@@ -2,7 +2,7 @@ process MERGE_FILTER_BAM {
     def process_name = "merge_filter_bam"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
-    publishDir "${launchDir}/output/results/bam", mode: 'copy'
+    publishDir "${launchDir}/output/results/bam", mode: 'copy', pattern: "*.bam*"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/merge_filter_bam.nf
+++ b/nextflow/modules/merge_filter_bam.nf
@@ -2,6 +2,7 @@ process MERGE_FILTER_BAM {
     def process_name = "merge_filter_bam"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/bam", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/merge_filter_bam.nf
+++ b/nextflow/modules/merge_filter_bam.nf
@@ -1,7 +1,7 @@
 process MERGE_FILTER_BAM {
     def process_name = "merge_filter_bam"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/merge_filtered.nf
+++ b/nextflow/modules/merge_filtered.nf
@@ -1,7 +1,7 @@
 process MERGE_FILTERED {
     def process_name = "merge_filtered"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 

--- a/nextflow/modules/merge_filtered.nf
+++ b/nextflow/modules/merge_filtered.nf
@@ -2,6 +2,7 @@ process MERGE_FILTERED {
     def process_name = "merge_filtered"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/vcf/filtered", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 

--- a/nextflow/modules/merge_masks.nf
+++ b/nextflow/modules/merge_masks.nf
@@ -1,7 +1,7 @@
 process MERGE_MASKS {
     def process_name = "merge_masks"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/merge_vcfs.nf
+++ b/nextflow/modules/merge_vcfs.nf
@@ -1,7 +1,7 @@
 process MERGE_VCFS {
     def process_name = "merge_vcfs"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21:BCFtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/multiqc.nf
+++ b/nextflow/modules/multiqc.nf
@@ -2,6 +2,7 @@ process MULTIQC {
     def process_name = "multiqc"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/qc", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "MultiQC/1.28-foss-2024a"
 

--- a/nextflow/modules/multiqc.nf
+++ b/nextflow/modules/multiqc.nf
@@ -1,7 +1,7 @@
 process MULTIQC {
     def process_name = "multiqc"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "MultiQC/1.28-foss-2024a"
 

--- a/nextflow/modules/plot_ordination.nf
+++ b/nextflow/modules/plot_ordination.nf
@@ -1,7 +1,7 @@
 process PLOT_ORDINATION {
     def process_name = "plot_ordination"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "shifter/22.02.1"
 

--- a/nextflow/modules/plot_ordination.nf
+++ b/nextflow/modules/plot_ordination.nf
@@ -2,6 +2,7 @@ process PLOT_ORDINATION {
     def process_name = "plot_ordination"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/visualisation", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "shifter/22.02.1"
 

--- a/nextflow/modules/plot_ordination.nf
+++ b/nextflow/modules/plot_ordination.nf
@@ -1,0 +1,24 @@
+process PLOT_ORDINATION {
+    def process_name = "plot_ordination"    
+    // tag "-"
+    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    // container "jackscanlan/piperline-multi:0.0.1"
+    module "shifter/22.02.1"
+
+    input:
+    path(distmat)
+    val(covariance)
+
+    output: 
+    path("*.pdf"),             emit: plots
+
+    script:
+    def process_script = "${process_name}.R"
+    """
+    shifter --image=jackscanlan/piperline-multi:0.0.1 -- \
+        ${projectDir}/bin/${process_script} \
+        ${projectDir} \
+        ${params.rdata} \
+        ${params.covariance}
+    """
+}

--- a/nextflow/modules/plot_ordination.nf
+++ b/nextflow/modules/plot_ordination.nf
@@ -2,7 +2,7 @@ process PLOT_ORDINATION {
     def process_name = "plot_ordination"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
-    publishDir "${launchDir}/output/results/visualisation", mode: 'copy'
+    publishDir "${launchDir}/output/results/visualisation/ordination", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "shifter/22.02.1"
 

--- a/nextflow/modules/plot_ordination.nf
+++ b/nextflow/modules/plot_ordination.nf
@@ -19,6 +19,6 @@ process PLOT_ORDINATION {
         ${projectDir}/bin/${process_script} \
         ${projectDir} \
         ${params.rdata} \
-        ${params.covariance}
+        ${covariance}
     """
 }

--- a/nextflow/modules/plot_ordination.nf
+++ b/nextflow/modules/plot_ordination.nf
@@ -7,6 +7,7 @@ process PLOT_ORDINATION {
 
     input:
     path(distmat)
+    path(popmap)
     val(covariance)
 
     output: 
@@ -19,6 +20,8 @@ process PLOT_ORDINATION {
         ${projectDir}/bin/${process_script} \
         ${projectDir} \
         ${params.rdata} \
+        ${distmat} \
+        ${popmap} \
         ${covariance}
     """
 }

--- a/nextflow/modules/plot_tree.nf
+++ b/nextflow/modules/plot_tree.nf
@@ -2,7 +2,7 @@ process PLOT_TREE {
     def process_name = "plot_tree"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
-    publishDir "${launchDir}/output/results/visualisation", mode: 'copy'
+    publishDir "${launchDir}/output/results/visualisation/trees", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "shifter/22.02.1"
 

--- a/nextflow/modules/plot_tree.nf
+++ b/nextflow/modules/plot_tree.nf
@@ -14,7 +14,7 @@ process PLOT_TREE {
     script:
     def process_script = "${process_name}.R"
     """
-    shifter --image=xushuangbin/ggtreeextraarticleenv:latest -- \
+    shifter --image=gmboowa/ggtree:latest -- \
         ${projectDir}/bin/${process_script} \
         ${projectDir} \
         ${params.rdata}

--- a/nextflow/modules/plot_tree.nf
+++ b/nextflow/modules/plot_tree.nf
@@ -1,7 +1,7 @@
 process PLOT_TREE {
     def process_name = "plot_tree"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "shifter/22.02.1"
 

--- a/nextflow/modules/plot_tree.nf
+++ b/nextflow/modules/plot_tree.nf
@@ -7,7 +7,7 @@ process PLOT_TREE {
 
     input:
     path(distmat)
-    tuple val(sample), val(pop)
+    path(popmap)
 
     output: 
     path("*.pdf"),             emit: plots
@@ -19,6 +19,7 @@ process PLOT_TREE {
         ${projectDir}/bin/${process_script} \
         ${projectDir} \
         ${params.rdata} \
-        
+        ${distmat} \
+        ${popmap}
     """
 }

--- a/nextflow/modules/plot_tree.nf
+++ b/nextflow/modules/plot_tree.nf
@@ -2,6 +2,7 @@ process PLOT_TREE {
     def process_name = "plot_tree"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/visualisation", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "shifter/22.02.1"
 

--- a/nextflow/modules/plot_tree.nf
+++ b/nextflow/modules/plot_tree.nf
@@ -7,6 +7,7 @@ process PLOT_TREE {
 
     input:
     path(distmat)
+    tuple val(sample), val(pop)
 
     output: 
     path("*.pdf"),             emit: plots
@@ -17,6 +18,7 @@ process PLOT_TREE {
     shifter --image=gmboowa/ggtree:latest -- \
         ${projectDir}/bin/${process_script} \
         ${projectDir} \
-        ${params.rdata}
+        ${params.rdata} \
+        
     """
 }

--- a/nextflow/modules/plot_tree.nf
+++ b/nextflow/modules/plot_tree.nf
@@ -14,7 +14,7 @@ process PLOT_TREE {
     script:
     def process_script = "${process_name}.R"
     """
-    shifter --image=jackscanlan/piperline-multi:0.0.1 -- \
+    shifter --image=xushuangbin/ggtreeextraarticleenv:latest -- \
         ${projectDir}/bin/${process_script} \
         ${projectDir} \
         ${params.rdata}

--- a/nextflow/modules/plot_tree.nf
+++ b/nextflow/modules/plot_tree.nf
@@ -1,0 +1,22 @@
+process PLOT_TREE {
+    def process_name = "plot_tree"    
+    // tag "-"
+    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    // container "jackscanlan/piperline-multi:0.0.1"
+    module "shifter/22.02.1"
+
+    input:
+    path(distmat)
+
+    output: 
+    path("*.pdf"),             emit: plots
+
+    script:
+    def process_script = "${process_name}.R"
+    """
+    shifter --image=jackscanlan/piperline-multi:0.0.1 -- \
+        ${projectDir}/bin/${process_script} \
+        ${projectDir} \
+        ${params.rdata}
+    """
+}

--- a/nextflow/modules/plot_variant_qc.nf
+++ b/nextflow/modules/plot_variant_qc.nf
@@ -1,7 +1,7 @@
 process PLOT_VARIANT_QC {
     def process_name = "plot_variant_qc"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "shifter/22.02.1"
 

--- a/nextflow/modules/plot_variant_qc.nf
+++ b/nextflow/modules/plot_variant_qc.nf
@@ -2,6 +2,7 @@ process PLOT_VARIANT_QC {
     def process_name = "plot_variant_qc"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/qc", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "shifter/22.02.1"
 

--- a/nextflow/modules/population_callset.nf
+++ b/nextflow/modules/population_callset.nf
@@ -1,6 +1,6 @@
 process POPULATION_CALLSET {
     def process_name = "population_callset"    
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "GATK/4.6.1.0-GCCcore-13.3.0-Java-21"
 

--- a/nextflow/modules/process_bam_mito.nf
+++ b/nextflow/modules/process_bam_mito.nf
@@ -1,7 +1,7 @@
 process PROCESS_BAM_MITO {
     def process_name = "process_bam_mito"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "SAMtools/1.21-GCC-13.3.0"
 

--- a/nextflow/modules/process_template_bash.nf
+++ b/nextflow/modules/process_template_bash.nf
@@ -1,10 +1,7 @@
 process PROCESS_TEMPLATE_BASH {
     def process_name = "process_template_bash"    
     // tag "-"
-    // label "small"
-    time '5.m'
-    memory '4.GB'
-    cpus 1
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     // module ""
 

--- a/nextflow/modules/process_template_r.nf
+++ b/nextflow/modules/process_template_r.nf
@@ -1,11 +1,7 @@
 process PROCESS_TEMPLATE_R {
     def process_name = "process_template_r"    
     // tag "-"
-    // label "small"
-    time '5.m'
-    memory '4.GB'
-    cpus 1
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     // module ""
 

--- a/nextflow/modules/split_fastq.nf
+++ b/nextflow/modules/split_fastq.nf
@@ -1,7 +1,7 @@
 process SPLIT_FASTQ {
     def process_name = "split_fastq"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "seqtk/1.4-GCC-13.3.0"
 

--- a/nextflow/modules/summarise_masks.nf
+++ b/nextflow/modules/summarise_masks.nf
@@ -2,6 +2,7 @@ process SUMMARISE_MASKS {
     def process_name = "summarise_masks"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/masks", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/summarise_masks.nf
+++ b/nextflow/modules/summarise_masks.nf
@@ -2,7 +2,7 @@ process SUMMARISE_MASKS {
     def process_name = "summarise_masks"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
-    publishDir "${launchDir}/output/results/masks", mode: 'copy'
+    publishDir "${launchDir}/output/results/qc", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/summarise_masks.nf
+++ b/nextflow/modules/summarise_masks.nf
@@ -1,7 +1,7 @@
 process SUMMARISE_MASKS {
     def process_name = "summarise_masks"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BEDTools/2.31.1-GCC-13.3.0"
 

--- a/nextflow/modules/vcf2dist.nf
+++ b/nextflow/modules/vcf2dist.nf
@@ -7,10 +7,9 @@ process VCF2DIST {
 
     input:
     tuple path(vcf), path(vcf_tbi)
-    tuple path(ref_genome), path(genome_index_files)
 
     output: 
-    path("*.mat"),                           emit: beagle
+    path("*.mat"),                           emit: mat
     
     script:
     def process_script = "${process_name}.sh"
@@ -20,8 +19,7 @@ process VCF2DIST {
     ### run process script
     bash ${process_script} \
         ${task.cpus} \
-        ${vcf} \
-        ${ref_genome} 
+        ${vcf}
 
     """
 }

--- a/nextflow/modules/vcf2dist.nf
+++ b/nextflow/modules/vcf2dist.nf
@@ -2,6 +2,7 @@ process VCF2DIST {
     def process_name = "vcf2dist"    
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
+    publishDir "${launchDir}/output/results/distmat", mode: 'copy'
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BCFtools/1.21-GCC-13.3.0:VCF2Dis/1.53-GCC-13.3.0"
 

--- a/nextflow/modules/vcf2dist.nf
+++ b/nextflow/modules/vcf2dist.nf
@@ -1,0 +1,27 @@
+process VCF2DIST {
+    def process_name = "vcf2dist"    
+    // tag "-"
+    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    // container "jackscanlan/piperline-multi:0.0.1"
+    module "BCFtools/1.21-GCC-13.3.0:VCF2Dis/1.53-GCC-13.3.0"
+
+    input:
+    tuple path(vcf), path(vcf_tbi)
+    tuple path(ref_genome), path(genome_index_files)
+
+    output: 
+    path("*.mat"),                           emit: beagle
+    
+    script:
+    def process_script = "${process_name}.sh"
+    """
+    #!/usr/bin/env bash
+    
+    ### run process script
+    bash ${process_script} \
+        ${task.cpus} \
+        ${vcf} \
+        ${ref_genome} 
+
+    """
+}

--- a/nextflow/modules/vcf2dist.nf
+++ b/nextflow/modules/vcf2dist.nf
@@ -1,7 +1,7 @@
 process VCF2DIST {
     def process_name = "vcf2dist"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BCFtools/1.21-GCC-13.3.0:VCF2Dis/1.53-GCC-13.3.0"
 

--- a/nextflow/modules/vcf_stats.nf
+++ b/nextflow/modules/vcf_stats.nf
@@ -1,7 +1,7 @@
 process VCF_STATS {
     def process_name = "vcf_stats"    
     // tag "-"
-    publishDir "${projectDir}/output/modules/${process_name}",  mode: 'copy'
+    publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
     module "BCFtools/1.21-GCC-13.3.0"
 

--- a/nextflow/subworkflows/filter_variants.nf
+++ b/nextflow/subworkflows/filter_variants.nf
@@ -132,7 +132,9 @@ workflow FILTER_VARIANTS {
         .set { ch_reports}
         
     emit: 
-    filtered_vcf = MERGE_FILTERED.out.vcf
+    filtered_merged = MERGE_FILTERED.out.vcf
+    filtered_snps = FILTER_SNPS.out.vcf
+    filtered_indels = FILTER_INDELS.out.vcf
     reports = ch_reports
 
 }

--- a/nextflow/subworkflows/lowcov_outputs.nf
+++ b/nextflow/subworkflows/lowcov_outputs.nf
@@ -45,8 +45,6 @@ workflow LOWCOV_OUTPUTS {
         .mix(CREATE_PSEUDOHAP.out.vcf)
         .set{ ch_vcfs }
 
-    ch_vcfs.view()
-
     VCF2DIST (
         ch_vcfs
     )

--- a/nextflow/subworkflows/lowcov_outputs.nf
+++ b/nextflow/subworkflows/lowcov_outputs.nf
@@ -39,6 +39,17 @@ workflow LOWCOV_OUTPUTS {
         ch_genome_indexed
     )
 
+    // Create distance matrices
+    ch_filtered_vcf
+        .mix(CREATE_PSEUDOHAP.out.vcf)
+        .set(ch_vcfs)
+
+    ch_vcfs.view()
+
+    VCF2DIST (
+        ch_vcfs
+    )
+
     emit: 
     beagle_gl = CREATE_BEAGLE_GL.out.beagle
     beagle_gp = CREATE_BEAGLE_GP.out.beagle

--- a/nextflow/subworkflows/lowcov_outputs.nf
+++ b/nextflow/subworkflows/lowcov_outputs.nf
@@ -6,6 +6,7 @@
 include { CREATE_BEAGLE as CREATE_BEAGLE_GL                      } from '../modules/create_beagle' 
 include { CREATE_BEAGLE as CREATE_BEAGLE_GP                      } from '../modules/create_beagle' 
 include { CREATE_PSEUDOHAP                                       } from '../modules/create_pseudohap' 
+include { VCF2DIST                                               } from '../modules/vcf2dist' 
 
 workflow LOWCOV_OUTPUTS {
 
@@ -42,13 +43,22 @@ workflow LOWCOV_OUTPUTS {
     // Create distance matrices
     ch_filtered_vcf
         .mix(CREATE_PSEUDOHAP.out.vcf)
-        .set(ch_vcfs)
+        .set{ ch_vcfs }
 
     ch_vcfs.view()
 
     VCF2DIST (
         ch_vcfs
     )
+
+    // TODO - create ordination plot
+    // This should take in a distance matrix or covariant matrix
+    // Use any population labels specified in the input file for labelling and colours
+
+
+    // TODO - Create NJ tree
+    // This should take in just a distance matrix
+    // Use any population labels specified in the input file for labelling and colours
 
     emit: 
     beagle_gl = CREATE_BEAGLE_GL.out.beagle

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -64,9 +64,9 @@ workflow OUTPUTS {
 
     // Create NJ tree
     // TODO: Use any population labels specified in the input file for labelling and colours
-    //PLOT_TREE (
-    //    VCF2DIST.out.mat
-    //)
+    PLOT_TREE (
+        VCF2DIST.out.mat
+    )
 
     emit: 
     beagle_gl = CREATE_BEAGLE_GL.out.beagle

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -1,5 +1,5 @@
 /*
-    Low coverage outputs
+    Create outputs
 */
 
 //// import modules
@@ -8,7 +8,7 @@ include { CREATE_BEAGLE as CREATE_BEAGLE_GP                      } from '../modu
 include { CREATE_PSEUDOHAP                                       } from '../modules/create_pseudohap' 
 include { VCF2DIST                                               } from '../modules/vcf2dist' 
 
-workflow LOWCOV_OUTPUTS {
+workflow OUTPUTS {
 
     take:
     ch_filtered_vcf

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -15,6 +15,7 @@ workflow OUTPUTS {
     take:
     ch_filtered_vcf
     ch_genome_indexed
+    ch_sample_pop
 
     main: 
 
@@ -56,14 +57,15 @@ workflow OUTPUTS {
     // TODO: Use any population labels specified in the input file for labelling and colours
     PLOT_ORDINATION (
         VCF2DIST.out.mat,
+        ch_sample_pop,
         false
     )
 
     // Create NJ tree
     // TODO: Use any population labels specified in the input file for labelling and colours
-    PLOT_TREE (
-        VCF2DIST.out.mat
-    )
+    //PLOT_TREE (
+    //    VCF2DIST.out.mat
+    //)
 
     emit: 
     beagle_gl = CREATE_BEAGLE_GL.out.beagle

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -8,6 +8,7 @@ include { CREATE_BEAGLE as CREATE_BEAGLE_GP                      } from '../modu
 include { CREATE_PSEUDOHAP                                       } from '../modules/create_pseudohap' 
 include { VCF2DIST                                               } from '../modules/vcf2dist' 
 include { PLOT_ORDINATION                                        } from '../modules/plot_ordination' 
+include { PLOT_TREE                                              } from '../modules/plot_tree' 
 
 workflow OUTPUTS {
 
@@ -52,15 +53,17 @@ workflow OUTPUTS {
 
     // create ordination plot
     // This should take in a distance matrix or covariant matrix
-    // Use any population labels specified in the input file for labelling and colours
+    // TODO: Use any population labels specified in the input file for labelling and colours
     PLOT_ORDINATION (
         VCF2DIST.out.mat,
         false
     )
 
-    // TODO - Create NJ tree
-    // This should take in just a distance matrix
-    // Use any population labels specified in the input file for labelling and colours
+    // Create NJ tree
+    // TODO: Use any population labels specified in the input file for labelling and colours
+    PLOT_TREE (
+        VCF2DIST.out.mat
+    )
 
     emit: 
     beagle_gl = CREATE_BEAGLE_GL.out.beagle

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -57,9 +57,10 @@ workflow OUTPUTS {
     // TODO: Use any population labels specified in the input file for labelling and colours
     PLOT_ORDINATION (
         VCF2DIST.out.mat,
-        ch_sample_pop,
         false
     )
+    // ch_sample_pop,
+
 
     // Create NJ tree
     // TODO: Use any population labels specified in the input file for labelling and colours

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -7,6 +7,7 @@ include { CREATE_BEAGLE as CREATE_BEAGLE_GL                      } from '../modu
 include { CREATE_BEAGLE as CREATE_BEAGLE_GP                      } from '../modules/create_beagle' 
 include { CREATE_PSEUDOHAP                                       } from '../modules/create_pseudohap' 
 include { VCF2DIST                                               } from '../modules/vcf2dist' 
+include { PLOT_ORDINATION                                        } from '../modules/plot_ordination' 
 
 workflow OUTPUTS {
 
@@ -49,10 +50,12 @@ workflow OUTPUTS {
         ch_vcfs
     )
 
-    // TODO - create ordination plot
+    // create ordination plot
     // This should take in a distance matrix or covariant matrix
     // Use any population labels specified in the input file for labelling and colours
-
+    PLOT_ORDINATION (
+        VCF2DIST.out.mat
+    )
 
     // TODO - Create NJ tree
     // This should take in just a distance matrix

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -13,9 +13,9 @@ include { PLOT_TREE                                              } from '../modu
 workflow OUTPUTS {
 
     take:
-    ch_filtered_merged,
-    ch_filtered_snps,
-    ch_filtered_indels,
+    ch_filtered_merged
+    ch_filtered_snps
+    ch_filtered_indels
     ch_genome_indexed
     ch_sample_pop
 

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -53,7 +53,7 @@ workflow OUTPUTS {
     )
 
     // create ordination plot
-    // This should take in a distance matrix or covariant matrix
+    // TODO: handle distance vs covariance matrix
     // TODO: Use any population labels specified in the input file for labelling and colours
     PLOT_ORDINATION (
         VCF2DIST.out.mat,
@@ -65,7 +65,8 @@ workflow OUTPUTS {
     // Create NJ tree
     // TODO: Use any population labels specified in the input file for labelling and colours
     PLOT_TREE (
-        VCF2DIST.out.mat
+        VCF2DIST.out.mat,
+        ch_sample_pop
     )
 
     emit: 

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -73,7 +73,7 @@ workflow OUTPUTS {
         false
     )
 
-    // create ordination plot from covariance matrices generated via PCA
+    // TODO: create ordination plot from covariance matrices generated via PCA
     //PLOT_ORDINATION (
     //    VCF2DIST.out.mat,
     //    ch_popmap,
@@ -85,11 +85,5 @@ workflow OUTPUTS {
         VCF2DIST.out.mat,
         ch_popmap
     )
-
-    emit: 
-    beagle_gl = CREATE_BEAGLE_GL.out.beagle
-    beagle_gp = CREATE_BEAGLE_GP.out.beagle
-    pseudo = CREATE_PSEUDOHAP.out.tsv
-
 
 }

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -53,22 +53,27 @@ workflow OUTPUTS {
     )
 
     // Turn ch_sample_pop tuples into a 2‑col TSV 'popmap' file
-    ch_popmap = ch_sample_pop
+    ch_sample_pop
         .map { s,p -> "$s\t$p" }
         .collectFile(name: 'sample_pop.tsv', newLine: true)
+        .first()
+        .set { ch_popmap }
 
-    // create ordination plot
-    // TODO: handle distance vs covariance matrix
-    // TODO: Use any population labels specified in the input file for labelling and colours
+    // create ordination plot from distance matrices
     PLOT_ORDINATION (
         VCF2DIST.out.mat,
+        ch_popmap,
         false
     )
-    // ch_sample_pop,
 
+    // create ordination plot from covariance matrices generated via PCA
+    //PLOT_ORDINATION (
+    //    VCF2DIST.out.mat,
+    //    ch_popmap,
+    //    true
+    //)
 
     // Create NJ tree
-    // TODO: Use any population labels specified in the input file for labelling and colours
     PLOT_TREE (
         VCF2DIST.out.mat,
         ch_popmap

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -54,7 +54,8 @@ workflow OUTPUTS {
     // This should take in a distance matrix or covariant matrix
     // Use any population labels specified in the input file for labelling and colours
     PLOT_ORDINATION (
-        VCF2DIST.out.mat
+        VCF2DIST.out.mat,
+        false
     )
 
     // TODO - Create NJ tree

--- a/nextflow/subworkflows/outputs.nf
+++ b/nextflow/subworkflows/outputs.nf
@@ -52,6 +52,11 @@ workflow OUTPUTS {
         ch_vcfs
     )
 
+    // Turn ch_sample_pop tuples into a 2‑col TSV 'popmap' file
+    ch_popmap = ch_sample_pop
+        .map { s,p -> "$s\t$p" }
+        .collectFile(name: 'sample_pop.tsv', newLine: true)
+
     // create ordination plot
     // TODO: handle distance vs covariance matrix
     // TODO: Use any population labels specified in the input file for labelling and colours
@@ -66,7 +71,7 @@ workflow OUTPUTS {
     // TODO: Use any population labels specified in the input file for labelling and colours
     PLOT_TREE (
         VCF2DIST.out.mat,
-        ch_sample_pop
+        ch_popmap
     )
 
     emit: 

--- a/nextflow/workflows/skimseq.nf
+++ b/nextflow/workflows/skimseq.nf
@@ -2,12 +2,12 @@
 
 //// import subworkflows
 // include { PROCESS_GENOME                                         } from '../subworkflows/process_genome'
-include { FILTER_VARIANTS                                           } from '../subworkflows/filter_variants'
-include { GATK_GENOTYPING                                           } from '../subworkflows/gatk_genotyping'
-include { LOWCOV_OUTPUTS                                            } from '../subworkflows/lowcov_outputs'
 include { PROCESS_READS                                             } from '../subworkflows/process_reads'
-include { MITO_GENOTYPING                                           } from '../subworkflows/mito_genotyping'
 include { MASK_GENOME                                               } from '../subworkflows/mask_genome'
+include { GATK_GENOTYPING                                           } from '../subworkflows/gatk_genotyping'
+include { MITO_GENOTYPING                                           } from '../subworkflows/mito_genotyping'
+include { FILTER_VARIANTS                                           } from '../subworkflows/filter_variants'
+include { OUTPUTS                                                   } from '../subworkflows/lowcov_outputs'
 
 //// import modules
 include { INDEX_GENOME                                              } from '../modules/index_genome' 
@@ -194,7 +194,7 @@ workflow SKIMSEQ {
     /*
     Custom output formats specific to low coverage sequencing
     */
-    LOWCOV_OUTPUTS (
+    OUTPUTS (
         FILTER_VARIANTS.out.filtered_vcf,
         ch_genome_indexed
     )

--- a/nextflow/workflows/skimseq.nf
+++ b/nextflow/workflows/skimseq.nf
@@ -40,18 +40,24 @@ workflow SKIMSEQ {
         .splitCsv ( by: 1, skip: 1 )
         .map { row -> [ 
             row[0],                                 // sample
-            file( row[1], checkIfExists: true ),    // read1 
-            file( row[2], checkIfExists: true )     // read2
+            row[1],                                 // population
+            file( row[2], checkIfExists: true ),    // read1 
+            file( row[3], checkIfExists: true )     // read2
             ] }
         .set { ch_reads }
 
 
     // Sample names channel
-    ch_samplesheet 
-        .splitCsv ( by: 1, skip: 1 )
-        .map { row -> row[0] }
+    ch_reads
+        .map { sample, pop, r1, r2 -> sample }
         .unique()
         .set { ch_sample_names }
+
+    // Sample names and pops
+    ch_reads
+        .map { sample, pop, r1, r2 -> [ sample, pop ] }
+        .unique()
+        .set { ch_sample_pop }
 
     // Reference genome channel
     if ( params.ref_genome ){
@@ -196,7 +202,8 @@ workflow SKIMSEQ {
     */
     OUTPUTS (
         FILTER_VARIANTS.out.filtered_vcf,
-        ch_genome_indexed
+        ch_genome_indexed,
+        ch_sample_pop
     )
 
     // Merge all reports for multiqc

--- a/nextflow/workflows/skimseq.nf
+++ b/nextflow/workflows/skimseq.nf
@@ -203,7 +203,9 @@ workflow SKIMSEQ {
     Custom output formats specific to low coverage sequencing
     */
     OUTPUTS (
-        FILTER_VARIANTS.out.filtered_vcf,
+        FILTER_VARIANTS.out.filtered_merged,
+        FILTER_VARIANTS.out.filtered_snps,
+        FILTER_VARIANTS.out.filtered_indels,
         ch_genome_indexed,
         ch_sample_pop
     )

--- a/nextflow/workflows/skimseq.nf
+++ b/nextflow/workflows/skimseq.nf
@@ -40,24 +40,26 @@ workflow SKIMSEQ {
         .splitCsv ( by: 1, skip: 1 )
         .map { row -> [ 
             row[0],                                 // sample
-            row[1],                                 // population
             file( row[2], checkIfExists: true ),    // read1 
             file( row[3], checkIfExists: true )     // read2
             ] }
         .set { ch_reads }
 
-
-    // Sample names channel
-    ch_reads
-        .map { sample, pop, r1, r2 -> sample }
-        .unique()
-        .set { ch_sample_names }
-
-    // Sample names and pops
-    ch_reads
-        .map { sample, pop, r1, r2 -> [ sample, pop ] }
+    // Sample names and pops channel
+    ch_samplesheet 
+        .splitCsv ( by: 1, skip: 1 )
+        .map { row -> [
+            row[0], // sample
+            row[1] // pop
+            ] }
         .unique()
         .set { ch_sample_pop }
+
+    // Sample names channel
+    ch_sample_pop
+        .map { sample, pop -> sample }
+        .unique()
+        .set { ch_sample_names }
 
     // Reference genome channel
     if ( params.ref_genome ){

--- a/nextflow/workflows/skimseq.nf
+++ b/nextflow/workflows/skimseq.nf
@@ -7,7 +7,7 @@ include { MASK_GENOME                                               } from '../s
 include { GATK_GENOTYPING                                           } from '../subworkflows/gatk_genotyping'
 include { MITO_GENOTYPING                                           } from '../subworkflows/mito_genotyping'
 include { FILTER_VARIANTS                                           } from '../subworkflows/filter_variants'
-include { OUTPUTS                                                   } from '../subworkflows/lowcov_outputs'
+include { OUTPUTS                                                   } from '../subworkflows/outputs'
 
 //// import modules
 include { INDEX_GENOME                                              } from '../modules/index_genome' 

--- a/test_data/qfly/test_samplesheet.csv
+++ b/test_data/qfly/test_samplesheet.csv
@@ -1,5 +1,5 @@
-sample_id,fwd,rev
-EM3,test_data/qfly/EM3_subset_R1.fastq.gz,test_data/qfly/EM3_subset_R2.fastq.gz
-EM6,test_data/qfly/EM6_subset_R1.fastq.gz,test_data/qfly/EM6_subset_R2.fastq.gz
-F2xM12-F1,test_data/qfly/F2xM12-F1_subset_R1.fastq.gz,test_data/qfly/F2xM12-F1_subset_R2.fastq.gz
-F3,test_data/qfly/F3_subset_R1.fastq.gz,test_data/qfly/F3_subset_R2.fastq.gz
+sample_id,pop,fwd,rev
+EM3,Pop1,test_data/qfly/EM3_subset_R1.fastq.gz,test_data/qfly/EM3_subset_R2.fastq.gz
+EM6,Pop1,test_data/qfly/EM6_subset_R1.fastq.gz,test_data/qfly/EM6_subset_R2.fastq.gz
+F2xM12-F1,Pop2,test_data/qfly/F2xM12-F1_subset_R1.fastq.gz,test_data/qfly/F2xM12-F1_subset_R2.fastq.gz
+F3,Pop3,test_data/qfly/F3_subset_R1.fastq.gz,test_data/qfly/F3_subset_R2.fastq.gz


### PR DESCRIPTION
This PR adds:

- Population structure visualisations #47

  - p-distance matrices are made from filtered GATK vcfs and pseudohaploid vcfs for SNPs and INDELS seperately and together in process `VCF2DIST`
  
  - MDS plots are made from p-distance matrices in process `PLOT_ORDINATION` 
  
  - NJ tree are made from p-distance matrices in process `PLOT_TREE`
  
- Population column input #35 

  - A population column input is added to samplesheet. The column is currently **Mandatory** but can be left blank.
  
  - The population column is currently only used for colouring samples on above visualisations, but can be used for other purposes in future
  
  - `test_data/qfly` samplesheet is updated to include population column

- Rework output directories #102

  - Important results are now output to `results` directory and subdirectories. `output/modules` directories are only created when debug mode is set
