### PR TITLE
map_to_genome bugfix and joint calling optimisations

### DIFF
--- a/bin/create_bed_intervals.sh
+++ b/bin/create_bed_intervals.sh
@@ -20,7 +20,7 @@ if (( java_mem < 1 )); then
 fi
 
 # parse interval_subdivide options
-if [[ ${7} == "true" ]];   then SUBDIVISION_MODE="--subdivision-mode INTERVAL_SUBDIVISION "; \
+if [[ ${7} == "true" ]];   then SUBDIVISION_MODE="--subdivision-mode INTERVAL_SUBDIVISION"; \
 else SUBDIVISION_MODE="--subdivision-mode  BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW"; fi
 
 # Convert any scientific notation to integers

--- a/bin/create_bed_intervals.sh
+++ b/bin/create_bed_intervals.sh
@@ -3,23 +3,32 @@ set -e
 set -u
 ## args are the following:
 # $1 = cpus 
-# $2 = interval_n
-# $3 = interval_size
-# $4 = include_bed     
-# $5 = exclude_bed
-# $6 = interval_subdivide_balanced
-# $7 = Reference_genome
+# $2 = mem
+# $3 = interval_n
+# $4 = interval_size
+# $5 = include_bed     
+# $6 = exclude_bed
+# $7 = interval_subdivide_balanced
+# $8 = Reference_genome
+
+# Mem for java should be 80% of assigned mem ($3) to leave room for C++ libraries
+java_mem=$(( ( ${2} * 80 ) / 100 ))   # 80% of assigned mem (integer floor)
+
+# Clamp to at least 1 GB so Java has something to start with
+if (( java_mem < 1 )); then
+    java_mem=1
+fi
 
 # parse interval_subdivide options
-if [[ ${6} == "true" ]];   then SUBDIVISION_MODE="--subdivision-mode INTERVAL_SUBDIVISION "; \
+if [[ ${7} == "true" ]];   then SUBDIVISION_MODE="--subdivision-mode INTERVAL_SUBDIVISION "; \
 else SUBDIVISION_MODE="--subdivision-mode  BALANCING_WITHOUT_INTERVAL_SUBDIVISION_WITH_OVERFLOW"; fi
 
 # Convert any scientific notation to integers
-interval_n=$(awk -v x="${2}" 'BEGIN {printf("%d\n",x)}')
-interval_size=$(awk -v x="${3}" 'BEGIN {printf("%d\n",x)}')
+interval_n=$(awk -v x="${3}" 'BEGIN {printf("%d\n",x)}')
+interval_size=$(awk -v x="${4}" 'BEGIN {printf("%d\n",x)}')
 
 # Exclude any intervals if exclusion files are not empty
-bedtools subtract -a ${4} -b ${5} > included_intervals.bed
+bedtools subtract -a ${4} -b ${6} > included_intervals.bed
 
 # Calculate number of groups
 if [ "$interval_size" -ge 0 ] && [ "$interval_n" -eq -1 ]; then
@@ -44,8 +53,8 @@ fi
 
 # Group current intervals into even groups of approximately even base content
 # Optionally subdivide furthr
-gatk SplitIntervals \
-   -R ${7} \
+gatk --java-options "-Xmx${java_mem}G -Xms${java_mem}g" SplitIntervals \
+   -R ${8} \
    -L included_intervals.bed \
    --scatter-count ${n_splits} \
    --interval-merging-rule OVERLAPPING_ONLY \
@@ -58,7 +67,7 @@ for i in *scattered.interval_list;do
   HASH=$( md5sum "$i" | awk '{print $1}' ) 
 
   # Convert resulting interval list to bed format
-  java -jar $EBROOTPICARD/picard.jar IntervalListToBed \
+  java "-Xmx${java_mem}G" -jar $EBROOTPICARD/picard.jar IntervalListToBed \
   	--INPUT $i \
   	--OUTPUT tmp.bed
 	

--- a/bin/create_bed_intervals.sh
+++ b/bin/create_bed_intervals.sh
@@ -28,7 +28,7 @@ interval_n=$(awk -v x="${3}" 'BEGIN {printf("%d\n",x)}')
 interval_size=$(awk -v x="${4}" 'BEGIN {printf("%d\n",x)}')
 
 # Exclude any intervals if exclusion files are not empty
-bedtools subtract -a ${4} -b ${6} > included_intervals.bed
+bedtools subtract -a ${5} -b ${6} > included_intervals.bed
 
 # Calculate number of groups
 if [ "$interval_size" -ge 0 ] && [ "$interval_n" -eq -1 ]; then

--- a/bin/extract_unmapped.sh
+++ b/bin/extract_unmapped.sh
@@ -4,33 +4,18 @@ set -u
 ## args are the following:
 # $1 = cpus 
 # $2 = sample name
-# $3 = list of sorted_bam files
-
-# get list of .bam files in directory
-ls *.bam > bam.list	
+# $3 = Sorted bam file
 
 # Create empty output files
 touch ${2}.unmapped.R1.fastq
 touch ${2}.unmapped.R2.fastq
 
-# Loop through bams
-for bam in *.bam; do
-    samtools sort -@ $1 -n $bam -O BAM \
-    | samtools bam2fq \
-  	-@ $1 \
-  	-1 R1.fastq \
-  	-2 R2.fastq \
-  	-0 /dev/null \
-  	-s /dev/null \
-  	-f12
-  	cat R1.fastq >> ${2}.unmapped.R1.fastq
-  	cat R2.fastq >> ${2}.unmapped.R2.fastq
-done
-
-# Zip output files
-gzip ${2}.unmapped.R1.fastq
-gzip ${2}.unmapped.R2.fastq
-
-# Remove temp files
-rm R1.fastq
-rm R2.fastq
+# Extract reads where only both pairs are unmapped (f12)
+samtools collate -@ $1 -u -O ${3} \
+| samtools fastq \
+-@ $1 \
+-1 ${2}.unmapped.R1.fastq.gz \
+-2 ${2}.unmapped.R2.fastq.gz \
+-0 /dev/null \
+-s /dev/null \
+-f12

--- a/bin/genomicsdb_import.sh
+++ b/bin/genomicsdb_import.sh
@@ -16,6 +16,14 @@ if (( java_mem < 1 )); then
     java_mem=1
 fi
 
+# reader threads should leave one thread free 
+reader_threads=$(( ${1} -1 ))
+
+# Clamp to at least 1
+if (( reader_threads < 1 )); then
+    reader_threads=1
+fi
+
 ## NOTE: .g.vcf files and their .tbi indexes are staged 
 
 # Create sample map file
@@ -36,7 +44,7 @@ gatk --java-options "-Xmx${java_mem}G -Xms${java_mem}g" GenomicsDBImport \
     --merge-input-intervals \
     --interval-merging-rule ALL \
     --bypass-feature-reader \
-    --reader-threads $(( ${1} -1 )) \
+    --reader-threads $reader_threads \
     --genomicsdb-shared-posixfs-optimizations \
     --consolidate
 

--- a/bin/genomicsdb_import.sh
+++ b/bin/genomicsdb_import.sh
@@ -34,4 +34,5 @@ gatk --java-options "-Xmx${java_mem}G -Xms${java_mem}g" GenomicsDBImport \
     --interval-merging-rule ALL \
     --bypass-feature-reader \
     --max-num-intervals-to-import-in-parallel ${1} \
-    --reader-threads 1
+    --reader-threads 1 \
+    --genomicsdb-shared-posixfs-optimizations true

--- a/bin/genomicsdb_import.sh
+++ b/bin/genomicsdb_import.sh
@@ -8,8 +8,8 @@ set -u
 # $4 = interval hash
 # $5 = interval_list
 
-# Mem for java should be 80% of assigned mem ($3) to leave room for C++ libraries
-java_mem=$(( ( ${2} * 80 ) / 100 ))   # 80% of assigned mem (integer floor)
+# Mem for java should be no more than 80% of task mem to leave room for genomicsDB C++ libraries
+java_mem=$(( ( ${2} * 80 ) / 100 ))   # 80% of task mem (integer floor)
 
 # Clamp to at least 1 GB so Java has something to start with
 if (( java_mem < 1 )); then
@@ -24,15 +24,20 @@ sample_id=$(echo "$vcf" | cut -f1 -d '.')
 paste -d '\t' <(echo "$sample_id") <(echo "$vcf") > ${4}.sample_map
 
 # Import gvcfs into genomicsdb
+# NOTES from GATK warp pipeline: https://github.com/broadinstitute/warp/blob/develop/tasks/broad/JointGenotypingTasks.wdl
+# testing has shown that the multithreaded reader initialization
+# does not scale well beyond 5 threads, so pointless increase beyond that.
 gatk --java-options "-Xmx${java_mem}G -Xms${java_mem}g" GenomicsDBImport \
     --genomicsdb-workspace-path ${4} \
-    --batch-size 0 \
+    --batch-size 50 \
     -L ${5} \
     --sample-name-map ${4}.sample_map \
     --tmp-dir /tmp \
-    --merge-input-intervals true \
+    --merge-input-intervals \
     --interval-merging-rule ALL \
     --bypass-feature-reader \
-    --max-num-intervals-to-import-in-parallel ${1} \
-    --reader-threads 1 \
-    --genomicsdb-shared-posixfs-optimizations true
+    --reader-threads $(( ${1} -1 )) \
+    --genomicsdb-shared-posixfs-optimizations \
+    --consolidate
+
+#  --max-num-intervals-to-import-in-parallel ${1} \ incompatible with merge-input-intevals

--- a/bin/joint_genotype.sh
+++ b/bin/joint_genotype.sh
@@ -32,7 +32,7 @@ if [[ "${9}" == "false" ]]; then
         --exclude-intervals ${7} \
         --interval-exclusion-padding ${8} \
         --interval-merging-rule ALL \
-        --merge-input-intervals true \
+        --merge-input-intervals \
         --only-output-calls-starting-in-intervals \
         --max-alternate-alleles 6 \
         --genomicsdb-max-alternate-alleles 10 \

--- a/bin/joint_genotype.sh
+++ b/bin/joint_genotype.sh
@@ -36,7 +36,8 @@ if [[ "${9}" == "false" ]]; then
         --only-output-calls-starting-in-intervals \
         --max-alternate-alleles 6 \
         --genomicsdb-max-alternate-alleles 10 \
-        --tmp-dir /tmp
+        --tmp-dir /tmp \
+        --genomicsdb-shared-posixfs-optimizations true
 
 elif [[ "${9}" == "true" ]]; then
     # Joint genotype both variant and invariant

--- a/bin/joint_genotype.sh
+++ b/bin/joint_genotype.sh
@@ -43,18 +43,10 @@ elif [[ "${9}" == "true" ]]; then
     # Joint genotype both variant and invariant
     # This requires some custom code to re-add missing genotpye fields for compatibility with later steps
 
-    # First use gatk selectvariants to get the sites to genotype
-    # This resolves the memory leak when calling invariant sites from genomicsDB reported in: https://github.com/broadinstitute/gatk/issues/8989
-    gatk --java-options "-Xmx${java_mem}G -Xms${java_mem}g"  SelectVariants \
-        -R ${4} \
-        -V gendb://${3} \
-        -L ${6} \
-        -O source.g.vcf.gz 
-
-    # Then genotype both variant and invariant sites using the gvcf
+    # genotype both variant and invariant sites 
     gatk --java-options "-Xmx${java_mem}G -Xms${java_mem}g"  GenotypeGVCFs \
         -R ${4} \
-        -V source.g.vcf.gz \
+        -V gendb://${3} \
         -L ${6} \
         -O calls.vcf.gz \
         --exclude-intervals ${7} \
@@ -62,8 +54,17 @@ elif [[ "${9}" == "true" ]]; then
         --interval-merging-rule ALL \
         --merge-input-intervals true \
         --only-output-calls-starting-in-intervals \
-        --include-non-variant-sites true \
-        --tmp-dir /tmp
+        --max-alternate-alleles 6 \
+        --genomicsdb-max-alternate-alleles 10 \
+        --tmp-dir /tmp \
+        --genomicsdb-shared-posixfs-optimizations true
+
+    # Get the sites as a GVCF as well to transfer the annotations over
+    gatk --java-options "-Xmx${java_mem}G -Xms${java_mem}g"  SelectVariants \
+        -R ${4} \
+        -V gendb://${3} \
+        -L ${6} \
+        -O source.g.vcf.gz 
 
      # Prepare annotation files for re-adding specific genotype fields to invariant sites
 

--- a/bin/map_to_genome.sh
+++ b/bin/map_to_genome.sh
@@ -75,13 +75,12 @@ if [[ ${21} == "none" ]]; then
 		- \
 	| samtools sort --threads ${1} -o ${2}.${CHUNK_NAME}.bam
 
-
 else 
     # use custom string of flags for fastp
     fastp \
         -i ${2}.${CHUNK_NAME}.F.fq \
         -I ${2}.${CHUNK_NAME}.R.fq \
-        ${18} \
+        ${21} \
 	--thread ${1} \
         -h ${2}.${CHUNK_NAME}.fastp.html \
         -j ${2}.${CHUNK_NAME}.fastp.json \
@@ -101,12 +100,14 @@ fi
 st=("${PIPESTATUS[@]}")
 names=("fastp" "bwa-mem2 mem" "samtools sort")
 
+# Default to exit code 0
 ec=0
 for i in "${!st[@]}"; do
   if (( st[i] != 0 )); then
     echo "${names[i]} failed with exit code ${st[i]}" >&2
-    # remember a non-zero to return
-    ec=${st[i]}                  
+    # take the first failing stage
+    ec=${st[i]}                         
+    break
   fi
 done
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -323,7 +323,7 @@ process {
         time    = { time_scale ( 30.m,   task.attempt ) }
     }
     withName: EXTRACT_UNMAPPED {
-        cpus    = { cpu_scale  ( 1,     task.attempt ) }
+        cpus    = { cpu_scale  ( 4,     task.attempt ) }
         memory  = { mem_scale  ( 8.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -332,7 +332,7 @@ process {
     //GATK_genotyping subworkflow Resources
     withName: CALL_VARIANTS {
         cpus    = { cpu_scale  ( 2,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+        memory  = { mem_scale  ( 16.GB,  task.attempt ) }
         time    = { time_scale ( 2.h,   task.attempt ) }
     }
     withName: GENOMICSDB_IMPORT {

--- a/nextflow.config
+++ b/nextflow.config
@@ -260,8 +260,8 @@ process {
     }    
     withName: CREATE_BED_INTERVALS {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 1.GB,  task.attempt ) }
-        time    = { time_scale ( 5.m,   task.attempt ) }
+        memory  = { mem_scale  ( 4.GB,  task.attempt ) }
+        time    = { time_scale ( 30.m,   task.attempt ) }
     }
     withName: MULTIQC {
         cpus    = { cpu_scale  ( 4,     task.attempt ) }

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,10 +23,10 @@ params {
     fastq_chunk_size            = 1E6                               // number of reads .fastq files should be split into for mapping to genome
     hc_interval_n               = 10                                // Create this many genomic intervals for parallel genotyping. Set to -1 to disable; integer
     hc_interval_size            = -1                                // Create genomic intervals of approximately this size. Set to -1 to disable; integer
-    interval_subdivide_balanced = true                              // Automatically subdivide intervals to balance number of bases in each parallel job; boolean
-    interval_subdivide_at_masks = true                              // Include hard masked regions inside intervals; boolean
-    interval_padding            = 100                               // Pad intervals by this many bases for genotyping; integer
-    jc_interval_sample_scale    = 0.15                              // Create jc_interval_sample_scale * N Samples intervals for joint calling; float/proportion
+    interval_subdivide_at_masks = true                              // Use masked regions (i.e. N's) to subdivide intervals; boolean  
+    interval_subdivide_balanced = false                             // Automatically subdivide intervals further to completely balance number of bases in each parallel job; boolean
+    interval_padding            = 500                               // Pad intervals by this many bases for genotyping; integer
+    jc_interval_sample_scale    = 0.5                               // Create jc_interval_sample_scale * N Samples intervals for joint calling; float/proportion
 
     ///// Reference genome masking for genotyping only (Not alignment)
     include_bed                 = null                              // Optional input bed file to just include these intervals for genotyping; path
@@ -261,7 +261,7 @@ process {
     withName: CREATE_BED_INTERVALS {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 16.GB,  task.attempt ) }
-        time    = { time_scale ( 30.m,   task.attempt ) }
+        time    = { time_scale ( 1.h,   task.attempt ) }
     }
     withName: MULTIQC {
         cpus    = { cpu_scale  ( 4,     task.attempt ) }
@@ -336,7 +336,7 @@ process {
         time    = { time_scale ( 2.h,   task.attempt ) }
     }
     withName: GENOMICSDB_IMPORT {
-        cpus    = { cpu_scale  ( 8,     task.attempt ) }
+        cpus    = { cpu_scale  ( 6,     task.attempt ) }
         memory  = { mem_scale  ( 48.GB,  task.attempt ) }
         time    = { time_scale ( 2.h,   task.attempt ) }
     }

--- a/nextflow.config
+++ b/nextflow.config
@@ -260,7 +260,7 @@ process {
     }    
     withName: CREATE_BED_INTERVALS {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 4.GB,  task.attempt ) }
+        memory  = { mem_scale  ( 16.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }
     }
     withName: MULTIQC {
@@ -347,29 +347,29 @@ process {
     }    
     withName: MERGE_VCFS {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+        memory  = { mem_scale  ( 48.GB,  task.attempt ) }
         time    = { time_scale ( 1.h,   task.attempt ) }
     }  
 
     // Filtering & Annotation resources
     withName: FILTER_VCF_GT{
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+        memory  = { mem_scale  ( 48.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }
     }
     withName: FILTER_VCF_SAMPLES{
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+        memory  = { mem_scale  ( 48.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }
     }
     withName: FILTER_VCF_SITES{
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+        memory  = { mem_scale  ( 48.GB,  task.attempt ) }
         time    = { time_scale ( 30.m,   task.attempt ) }
     }
     withName: ANNOTATE_VCF {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 8.GB,  task.attempt ) }
+        memory  = { mem_scale  ( 48.GB,  task.attempt ) }
         time    = { time_scale ( 1.h,   task.attempt ) }
     }  
     withName: PLOT_GT_FILTERS {

--- a/nextflow.config
+++ b/nextflow.config
@@ -342,8 +342,8 @@ process {
     }
     withName: JOINT_GENOTYPE {
         cpus    = { cpu_scale  ( 2,     task.attempt ) }
-        memory  = { mem_scale  ( 24.GB,  task.attempt ) }
-        time    = { time_scale ( 6.h,   task.attempt ) }
+        memory  = { mem_scale  ( 48.GB,  task.attempt ) }
+        time    = { time_scale ( 24.h,   task.attempt ) }
     }    
     withName: MERGE_VCFS {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
@@ -355,22 +355,22 @@ process {
     withName: FILTER_VCF_GT{
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 48.GB,  task.attempt ) }
-        time    = { time_scale ( 30.m,   task.attempt ) }
+        time    = { time_scale ( 6.h,   task.attempt ) }
     }
     withName: FILTER_VCF_SAMPLES{
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 48.GB,  task.attempt ) }
-        time    = { time_scale ( 30.m,   task.attempt ) }
+        time    = { time_scale ( 6.h,   task.attempt ) }
     }
     withName: FILTER_VCF_SITES{
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 48.GB,  task.attempt ) }
-        time    = { time_scale ( 30.m,   task.attempt ) }
+        time    = { time_scale ( 6.h,   task.attempt ) }
     }
     withName: ANNOTATE_VCF {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
         memory  = { mem_scale  ( 48.GB,  task.attempt ) }
-        time    = { time_scale ( 1.h,   task.attempt ) }
+        time    = { time_scale ( 6.h,   task.attempt ) }
     }  
     withName: PLOT_GT_FILTERS {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }

--- a/nextflow/modules/create_bed_intervals.nf
+++ b/nextflow/modules/create_bed_intervals.nf
@@ -24,6 +24,7 @@ process CREATE_BED_INTERVALS {
     ### run process script
     bash ${process_script} \
         ${task.cpus} \
+        ${task.memory.giga} \
         ${interval_n} \
         ${interval_size} \
         ${include_bed} \


### PR DESCRIPTION
This resolves https://github.com/AVR-biosecurity-bioinformatics/skimseq/issues/139 and makes some optimisations to joint calling following the [GATK WARP production pipeline](https://github.com/broadinstitute/warp/blob/develop/pipelines/broad/dna_seq/germline/joint_genotyping/JointGenotyping.wdl) - particularly around ensuring there is enough memory and CPUs available outside the GATK java environments for any native libraries, and significantly increasing runtime allowance for joint VCF processing steps.