### PR TITLE
Haplotypecaller & Other optimisations

### DIFF
--- a/bin/call_variants.sh
+++ b/bin/call_variants.sh
@@ -20,6 +20,14 @@ set -u
 # $16 = hc_minmq
 # $17 = ploidy
 
+# 1GB of memory should be retained outside the java heap
+java_mem=$(( ( ${2} - 1 )) 
+
+# Clamp to at least 1 GB so Java has something to start with
+if (( java_mem < 1 )); then
+    java_mem=1
+fi
+
 # parse filtering options as flags
 if [[ ${14} == "false" ]];    then RMDUP="-DF NotDuplicateReadFilter";                  else RMDUP=""; fi
 
@@ -28,7 +36,7 @@ echo ${4} | tr ' ' '\n' > bam.list
 
 # call variants per sample across all the bam chunks
 # NOTE: need to use assembly region padding rather than interval_padding to avoid overlapping variants
-gatk --java-options "-Xmx${2}G" HaplotypeCaller \
+gatk --java-options "-Xmx${java_mem}G -Xms${java_mem}g -XX:GCTimeLimit=50 -XX:GCHeapFreeLimit=10 -XX:ParallelGCThreads=${1}" HaplotypeCaller \
     -R $5 \
     -I bam.list \
     -L $7 \

--- a/bin/call_variants.sh
+++ b/bin/call_variants.sh
@@ -45,5 +45,5 @@ gatk --java-options "-Xmx${2}G" HaplotypeCaller \
     --min-base-quality-score ${15} \
     --minimum-mapping-quality ${16} \
     --mapping-quality-threshold-for-genotyping ${16} \
-    -ploidy ${16} \
+    -ploidy ${17} \
     -ERC GVCF

--- a/bin/call_variants.sh
+++ b/bin/call_variants.sh
@@ -21,7 +21,7 @@ set -u
 # $17 = ploidy
 
 # 1GB of memory should be retained outside the java heap
-java_mem=$(( ( ${2} - 1 )) 
+java_mem=$(( ( ${2} - 1 )))
 
 # Clamp to at least 1 GB so Java has something to start with
 if (( java_mem < 1 )); then

--- a/bin/call_variants.sh
+++ b/bin/call_variants.sh
@@ -16,8 +16,9 @@ set -u
 # $12 = hc_min_dangling_length
 # $13 = hc_max_reads_startpos
 # $14 = hc_rmdup
-# $15 = hc_minmq
-# $16 = ploidy
+# $15 = hc_minbq
+# $16 = hc_minmq
+# $17 = ploidy
 
 # parse filtering options as flags
 if [[ ${14} == "false" ]];    then RMDUP="-DF NotDuplicateReadFilter";                  else RMDUP=""; fi
@@ -37,12 +38,12 @@ gatk --java-options "-Xmx${2}G" HaplotypeCaller \
     --exclude-intervals ${9} \
     --interval-exclusion-padding ${10} \
     --interval-merging-rule ALL \
-    --min-base-quality-score 15 \
     --min-pruning ${11} \
     --min-dangling-branch-length ${12} \
     --max-reads-per-alignment-start ${13} \
     $RMDUP \
-    --minimum-mapping-quality ${15} \
-    --mapping-quality-threshold-for-genotyping ${15} \
+    --min-base-quality-score ${15} \
+    --minimum-mapping-quality ${16} \
+    --mapping-quality-threshold-for-genotyping ${16} \
     -ploidy ${16} \
     -ERC GVCF

--- a/bin/count_reads_bed.sh
+++ b/bin/count_reads_bed.sh
@@ -14,23 +14,15 @@ set -u
 # Exclude any intervals in exclude_bed, and ensure they contain only 3 columns
 bedtools subtract -a <(cut -f1-3 "${5}") -b <(cut -f1-3 "${6}") > included_intervals.bed
 
-# Count number of reads overlapping intervals
-#bedtools coverage \
-#    -a included_intervals.bed \
-#    -b ${3} \
-#    -g ${4}.fai \
-#    -sorted \
-#    -counts > ${7}.counts.bed
-
 # Count number of aligned reads and aligned bases overlapping intervals
 samtools bedcov included_intervals.bed "${3}" -c > counts.bed.tmp
 
 # Select columns based on mode
-if [[ "${8}" == "reads" ]]; then
-    awk '{print $1, $2, $3, $5}' counts.bed.tmp > ${7}.counts.bed
-elif [[ "${8}" == "bases" ]]; then
-    awk '{print $1, $2, $3, $4}' counts.bed.tmp > ${7}.counts.bed
-fi
+awk -v mode="${8}" 'BEGIN{OFS="\t"} 
+{
+    if(mode=="reads") print $1,$2,$3,$5
+    else if(mode=="bases") print $1,$2,$3,$4
+}' > ${7}.counts.bed
 
 # Remove temporary files
 rm -f counts.bed.tmp

--- a/bin/count_reads_bed.sh
+++ b/bin/count_reads_bed.sh
@@ -18,4 +18,5 @@ bedtools coverage \
     -a included_intervals.bed \
     -b ${3} \
     -g ${4}.fai \
+    -sorted \
     -counts > ${7}.counts.bed

--- a/bin/count_reads_bed.sh
+++ b/bin/count_reads_bed.sh
@@ -9,14 +9,28 @@ set -u
 # $5 = include_bed     
 # $6 = exclude_bed
 # $7 = sample
+# $8 = mode
 
 # Exclude any intervals in exclude_bed, and ensure they contain only 3 columns
 bedtools subtract -a <(cut -f1-3 "${5}") -b <(cut -f1-3 "${6}") > included_intervals.bed
 
 # Count number of reads overlapping intervals
-bedtools coverage \
-    -a included_intervals.bed \
-    -b ${3} \
-    -g ${4}.fai \
-    -sorted \
-    -counts > ${7}.counts.bed
+#bedtools coverage \
+#    -a included_intervals.bed \
+#    -b ${3} \
+#    -g ${4}.fai \
+#    -sorted \
+#    -counts > ${7}.counts.bed
+
+# Count number of aligned reads and aligned bases overlapping intervals
+samtools bedcov included_intervals.bed "${3}" -c > counts.bed.tmp
+
+# Select columns based on mode
+if [[ "$mode" == "reads" ]]; then
+    awk '{print $1, $2, $3, $5}' counts.bed.tmp > ${7}.counts.bed
+elif [[ "$mode" == "bases" ]]; then
+    awk '{print $1, $2, $3, $4}' counts.bed.tmp > ${7}.counts.bed
+fi
+
+# Remove temporary files
+rm -f counts.bed.tmp

--- a/bin/count_reads_bed.sh
+++ b/bin/count_reads_bed.sh
@@ -26,9 +26,9 @@ bedtools subtract -a <(cut -f1-3 "${5}") -b <(cut -f1-3 "${6}") > included_inter
 samtools bedcov included_intervals.bed "${3}" -c > counts.bed.tmp
 
 # Select columns based on mode
-if [[ "$mode" == "reads" ]]; then
+if [[ "${8}" == "reads" ]]; then
     awk '{print $1, $2, $3, $5}' counts.bed.tmp > ${7}.counts.bed
-elif [[ "$mode" == "bases" ]]; then
+elif [[ "${8}" == "bases" ]]; then
     awk '{print $1, $2, $3, $4}' counts.bed.tmp > ${7}.counts.bed
 fi
 

--- a/bin/count_reads_bed.sh
+++ b/bin/count_reads_bed.sh
@@ -22,7 +22,7 @@ awk -v mode="${8}" 'BEGIN{OFS="\t"}
 {
     if(mode=="reads") print $1,$2,$3,$5
     else if(mode=="bases") print $1,$2,$3,$4
-}' > ${7}.counts.bed
+}' counts.bed.tmp > ${7}.counts.bed
 
 # Remove temporary files
 rm -f counts.bed.tmp

--- a/nextflow.config
+++ b/nextflow.config
@@ -63,6 +63,7 @@ params {
     hc_min_dangling_length      = 4                                 // Minimum length of a dangling branch to attempt recovery. Smaller number increases sensitivity at expense of false positives; integer
     hc_max_reads_startpos       = 50                                // Maximum number of reads to retain per alignment start position. Increase if doing deep targetted sequencing; integer
     hc_rmdup                    = true                              // Exclude duplicate aligned reads from genotyping; logical
+    hc_minbq                    = 10                                // Minimum base quality for genotyping; integer
     hc_minmq                    = 20                                // Minimum mapping quality for genotyping; integer
     ploidy                      = 2                                 // Ploidy of the samples; integer
     output_invariant            = false                             // Whether to output invariant sites; logical

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,7 +51,7 @@ params {
     rf_cut_mean_quality         = 20                                // mean quality threshold to trigger trimming (passed to 'fastp cut_right_mean_quality'); integer
     rf_lc_filter                = true                              // read low complexity filter (enables 'fastp --low_complexity_filter'); boolean
     rf_lc_threshold             = 30                                // threshold for low complexity filter (passed to 'fastp --complexity_threshold'); integer
-    rf_correction               = true                              // correct bases in overlapping regions of paired-end reads (enables 'fastp --correction'); boolean
+    rf_correction               = false                             // correct bases in overlapping regions of paired-end reads (enables 'fastp --correction'). This should not be used for genotypers i.e. GATK which have inbuilt correction; boolean
     rf_overlap_length           = 30                                // minimum bp overlap for detection of paired-end overlap (passed to 'fastp --overlap_len_require'); integer
     rf_overlap_diff             = 5                                 // maximum mismatches for detection of paired-end overlap (passed to 'fastp --overlap_diff_limit'); integer
     rf_overlap_diff_pc          = 20                                // maximum % mismatches for detection of paired-end overlap, 20 = 20% (passed to 'fastp --overlap_diff_percent_limit'); integer

--- a/nextflow.config
+++ b/nextflow.config
@@ -237,6 +237,8 @@ profiles {
 
 
 process {
+    // Copy input/output files to/from on-node scratch
+    scratch = true
 
     // error handling
     errorStrategy = { task.exitStatus in ((130..145) + 104 + 247) ? 'retry' : 'finish' }
@@ -283,7 +285,7 @@ process {
     }  
     withName: COUNT_READS_BED {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 10.GB,  task.attempt ) }
+        memory  = { mem_scale  ( 4.GB,  task.attempt ) }
         time    = { time_scale ( 10.m,   task.attempt ) }
     }  
     withName: COUNT_VCF_BED {

--- a/nextflow.config
+++ b/nextflow.config
@@ -283,7 +283,7 @@ process {
     }  
     withName: COUNT_READS_BED {
         cpus    = { cpu_scale  ( 1,     task.attempt ) }
-        memory  = { mem_scale  ( 20.GB,  task.attempt ) }
+        memory  = { mem_scale  ( 10.GB,  task.attempt ) }
         time    = { time_scale ( 10.m,   task.attempt ) }
     }  
     withName: COUNT_VCF_BED {

--- a/nextflow.config
+++ b/nextflow.config
@@ -235,7 +235,7 @@ profiles {
 
 
 process {
-    // Copy input/output files to/from on-node scratch
+    // Use on-node scratch for individual processes
     scratch = true
 
     // error handling
@@ -354,7 +354,7 @@ process {
     withName: CALL_VARIANTS {
         cpus    = { cpu_scale  ( 2,     task.attempt ) }
         memory  = { mem_scale  ( 16.GB,  task.attempt ) }
-        time    = { time_scale ( 2.h,   task.attempt ) }
+        time    = { time_scale ( 12.h,   task.attempt ) }
     }
     withName: GENOMICSDB_IMPORT {
         cpus    = { cpu_scale  ( 6,     task.attempt ) }

--- a/nextflow.config
+++ b/nextflow.config
@@ -162,12 +162,10 @@ profiles {
         params.ref_genome               = 'test_data/qfly/test_qfly_genome.fa' // Qfly genome subset to 50-100kb
         params.mito_contig              = 'HQ130030.1'
         params.fastq_chunk_size	      	= 3000
-        params.hc_interval_size         = 1E4
-        params.hc_bases_per_chunk       = 1E4 
+        params.hc_bases_per_chunk       = 1E5 
         params.jc_genotypes_per_chunk   = 1E4                    
         params.use_reference_hardmasks  = true
         params.use_reference_softmasks  = true
-        params.jc_interval_min_n        = 2
         params.min_chr_length           = 20000
         params.include_bed              = 'test_data/qfly/include_interval.bed'
         params.exclude_bed              = 'test_data/qfly/exclude_interval.bed'

--- a/nextflow/modules/call_variants.nf
+++ b/nextflow/modules/call_variants.nf
@@ -11,7 +11,7 @@ process CALL_VARIANTS {
     
     path(exclude_bed)
     val(exclude_padding)
-    tuple val(hc_interval_padding), val(hc_min_pruning), val(hc_min_dangling_length), val(hc_max_reads_startpos), val(hc_rmdup), val(hc_minmq), val(ploidy)
+    tuple val(hc_interval_padding), val(hc_min_pruning), val(hc_min_dangling_length), val(hc_max_reads_startpos), val(hc_rmdup), val(hc_minbq), val(hc_minmq), val(ploidy)
 
     output: 
     tuple val(sample), path("*.g.vcf.gz"), path("*.g.vcf.gz.tbi"), val(interval_hash), path(interval_bed),     emit: gvcf_intervals
@@ -37,6 +37,7 @@ process CALL_VARIANTS {
         ${hc_min_dangling_length} \
         ${hc_max_reads_startpos} \
         ${hc_rmdup} \
+        ${hc_minbq} \
         ${hc_minmq} \
         ${ploidy} 
         

--- a/nextflow/modules/count_reads_bed.nf
+++ b/nextflow/modules/count_reads_bed.nf
@@ -6,13 +6,12 @@ process COUNT_READS_BED {
     module "BEDTools/2.31.1-GCC-13.3.0:SAMtools/1.22.1-GCC-13.3.0"
 
     input:
-    tuple val(sample), path(bam, name: '*sorted.bam'), path(bam_index, name: '*sorted.bam.bai')
+    tuple val(sample), path(bam), path(bam_index)
     path(interval_bed)
     path(exclude_bed)
     tuple path(ref_genome), path(genome_index_files)
     val(mode)
     
-
     output: 
     tuple val(sample), path("*counts.bed"),                 emit: counts
     

--- a/nextflow/modules/count_reads_bed.nf
+++ b/nextflow/modules/count_reads_bed.nf
@@ -3,13 +3,14 @@ process COUNT_READS_BED {
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
-    module "BEDTools/2.31.1-GCC-13.3.0"
+    module "BEDTools/2.31.1-GCC-13.3.0:SAMtools/1.22.1-GCC-13.3.0"
 
     input:
     tuple val(sample), path(bam, name: '*sorted.bam'), path(bam_index, name: '*sorted.bam.bai')
     path(interval_bed)
     path(exclude_bed)
     tuple path(ref_genome), path(genome_index_files)
+    val(mode)
 
     output: 
     tuple val(sample), path("*counts.bed"),                 emit: counts
@@ -27,7 +28,8 @@ process COUNT_READS_BED {
         ${ref_genome} \
         ${interval_bed} \
         ${exclude_bed} \
-        ${sample}
+        ${sample} \
+        ${mode}
         
     """
 }

--- a/nextflow/modules/count_reads_bed.nf
+++ b/nextflow/modules/count_reads_bed.nf
@@ -11,6 +11,7 @@ process COUNT_READS_BED {
     path(exclude_bed)
     tuple path(ref_genome), path(genome_index_files)
     val(mode)
+    
 
     output: 
     tuple val(sample), path("*counts.bed"),                 emit: counts

--- a/nextflow/modules/create_interval_chunks.nf
+++ b/nextflow/modules/create_interval_chunks.nf
@@ -3,7 +3,7 @@ process CREATE_INTERVAL_CHUNKS {
     // tag "-"
     publishDir "${launchDir}/output/modules/${process_name}", mode: 'copy', enabled: "${ params.debug_mode ? true : false }"
     // container "jackscanlan/piperline-multi:0.0.1"
-    module "BEDTools/2.31.1-GCC-13.3.0:GATK/4.6.1.0-GCCcore-13.3.0-Java-21:picard/3.3.0-Java-21"
+    module "BEDTools/2.31.1-GCC-13.3.0"
 
     input:
     val(counts_per_chunk)

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -73,6 +73,7 @@ workflow GATK_GENOTYPING {
         params.hc_min_dangling_length,
         params.hc_max_reads_startpos,
         params.hc_rmdup,
+        params.hc_minbq,
         params.hc_minmq,
         params.ploidy,
     )

--- a/nextflow/subworkflows/gatk_genotyping.nf
+++ b/nextflow/subworkflows/gatk_genotyping.nf
@@ -35,7 +35,8 @@ workflow GATK_GENOTYPING {
         ch_sample_bam,
         ch_include_bed.first(),
         ch_mask_bed_gatk,
-        ch_genome_indexed
+        ch_genome_indexed,
+        "bases"
     )
 
     // Create haplotypecaller intervals


### PR DESCRIPTION
A few general optimisations:

- Fixes a bug where interval assignment for haplotypecaller intervals were created based on number of aligned reads rather than aligned bases.
- Add `hc_minbq` for changing base quality filtering
- Makes a couple of java and nextflow resource allocation optimisations for haplotypecaller to avoid timeouts.
- Turns fastp base correction off by default to avoid double-correction by haplotypecaller resolves #105 
- Enabled nextflow `process.scratch=true` directive so that jobs create temp files in compute node scratch rather than work directory